### PR TITLE
Github actions workflow for creating, testing and uploading package wheels

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -44,7 +44,7 @@ jobs:
         sudo make install
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_MODULE_PATH=/usr/local/share/cmake/Modules
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,140 @@
+name: Build Wheels
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  release:
+    types: [ published ]
+
+jobs:
+  build_wheels_linux:
+    name: Build wheels for cp3${{ matrix.python_version_minor }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version_minor: [8, 9, 10, 11, 12]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.${{ matrix.python_version_minor }}
+          architecture: x64
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade patchelf auditwheel
+          ./wheels/install_deps.sh
+
+      - name: Build wheel
+        run: >
+          CMAKE_ARGS="-DCMAKE_MODULE_PATH=$PWD/deps/share/cmake/Modules -DCMAKE_PREFIX_PATH=$PWD/deps"
+          pip wheel . -w wheelhouse -vvv
+
+      - name: Repair wheel
+        run: >
+          auditwheel -v repair ./wheelhouse/tuberd*.whl
+          --exclude libpython3.${{ matrix.python_version_minor }}.so
+          --plat manylinux_2_31_x86_64
+
+      - name: Install wheel for tests
+        run: pip install ./wheelhouse/tuberd*manylinux*.whl
+
+      - name: Run tests
+        run: |
+          cd tests
+          ./test.py --import-mode append
+          ./test.py --import-mode append --orjson-with-numpy
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ runner.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/tuberd*manylinux*.whl
+
+  build_wheels_osx:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # macos-13 is an intel runner, macos-14 is apple silicon
+          - os: macos-13
+            target: 10.15
+          - os: macos-14
+            target: 11.0
+
+    steps:
+      - name: Set macOS deployment target
+        run: echo "MACOSX_DEPLOYMENT_TARGET=${{ matrix.target }}" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.20.0
+        env:
+          CIBW_BEFORE_ALL: brew install automake libtool && ./wheels/install_deps.sh
+          CIBW_REPAIR_WHEEL_COMMAND: "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} -e Python.framework"
+          CIBW_ENVIRONMENT: CMAKE_ARGS="-DCMAKE_MODULE_PATH=$PWD/deps/share/cmake/Modules -DCMAKE_PREFIX_PATH=$PWD/deps"
+          CIBW_BUILD_VERBOSITY: 3
+          CIBW_SKIP: cp36-* cp37-* cp313-* cp38-macosx_arm64 pp*
+          CIBW_TEST_COMMAND: >
+            {project}/tests/test.py --import-mode append &&
+            {project}/tests/test.py --import-mode append --orjson-with-numpy
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/tuberd*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels_linux, build_wheels_osx, build_sdist]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # unpacks all CIBW artifacts into dist/
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,9 +37,7 @@ jobs:
           ./wheels/install_deps.sh
 
       - name: Build wheel
-        run: >
-          CMAKE_ARGS="-DCMAKE_MODULE_PATH=$PWD/deps/share/cmake/Modules -DCMAKE_PREFIX_PATH=$PWD/deps"
-          pip wheel . -w wheelhouse -vvv
+        run: pip wheel . -w wheelhouse -vvv
 
       - name: Repair wheel
         run: >
@@ -90,7 +88,6 @@ jobs:
         env:
           CIBW_BEFORE_ALL: brew install automake libtool && ./wheels/install_deps.sh
           CIBW_REPAIR_WHEEL_COMMAND: "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel} -e Python.framework"
-          CIBW_ENVIRONMENT: CMAKE_ARGS="-DCMAKE_MODULE_PATH=$PWD/deps/share/cmake/Modules -DCMAKE_PREFIX_PATH=$PWD/deps"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_SKIP: cp36-* cp37-* cp313-* cp38-macosx_arm64 pp*
           CIBW_TEST_COMMAND: >

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ cmake_install.cmake
 tuberd
 tuber/_version.py
 Pipfile
+deps/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,25 +4,24 @@
 cmake_minimum_required(VERSION 3.16...3.22)
 project(tuberd VERSION 1.0.0 LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 
-# Allow e.g. libhttpserver to be installed somewhere unexpected
-list(APPEND CMAKE_MODULE_PATH "/usr/local/share/cmake/Modules")
-
-find_package(Python COMPONENTS Interpreter Development)
+find_package(Python COMPONENTS Interpreter Development REQUIRED)
 find_package(fmt REQUIRED)
-find_package(LibHttpServer MODULE REQUIRED)
+find_package(LibHttpServer REQUIRED)
 find_package(pybind11 REQUIRED)
+find_package(Threads REQUIRED)
 
 include(CTest)
 
 add_executable(tuberd src/server.cpp)
-target_link_libraries(tuberd PRIVATE fmt::fmt ${LIBHTTPSERVER_LIBRARIES} pybind11::embed)
+target_link_libraries(tuberd PRIVATE fmt::fmt ${LIBHTTPSERVER_LIBRARIES} pybind11::embed Threads::Threads)
 
 pybind11_add_module(test_module MODULE tests/test_module.cpp)
 target_include_directories(test_module PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(test_module PRIVATE fmt::fmt)
 
 add_test(NAME test-native-json
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -33,7 +32,7 @@ add_test(NAME test-orjson-fastpath
 	COMMAND tests/test.py --orjson-with-numpy)
 
 set_tests_properties(test-native-json test-orjson-fastpath
-	PROPERTIES ENVIRONMENT "CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR};CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR};PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_SOURCE_DIR}")
+	PROPERTIES ENVIRONMENT "PATH=${CMAKE_BINARY_DIR}:$ENV{PATH};PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_SOURCE_DIR}")
 
 set_target_properties(tuberd PROPERTIES PUBLIC_HEADER "include/tuber_support.hpp")
 install(TARGETS tuberd PUBLIC_HEADER DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,13 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 
+# link against deps dir
+if(EXISTS ${CMAKE_SOURCE_DIR}/deps)
+	message(STATUS "Found deps: ${CMAKE_SOURCE_DIR}/deps")
+	list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/deps/share/cmake/Modules")
+	list(APPEND CMAKE_PREFIX_PATH "${CMAKE_SOURCE_DIR}/deps")
+endif()
+
 find_package(Python COMPONENTS Interpreter Development REQUIRED)
 find_package(fmt REQUIRED)
 find_package(LibHttpServer REQUIRED)

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+.. image:: https://badge.fury.io/py/tuberd.svg
+   :target: https://badge.fury.io/py/tuberd
+
+.. image:: https://github.com/gsmecher/tuberd/actions/workflows/package.yml/badge.svg
+   :target: https://github.com/gsmecher/tuberd/actions/workflows/package.yml
+
 Tuber Server and Client
 =======================
 
@@ -122,3 +128,21 @@ licensing is a stumbling block for you, please contact me at
 .. _asyncio: https://docs.python.org/3/library/asyncio.html
 .. _aiohttp: https://docs.aiohttp.org/en/stable/
 .. _autoawait: https://ipython.readthedocs.io/en/stable/interactive/autoawait.html
+
+Installation
+------------
+
+Pre-built wheels for Linux and macOS operating systems are available on PyPI for CPython 3.8+:
+
+.. code:: bash
+
+   pip install tuberd
+
+Building from source requires the `libfmt` and `libmicrohttpd` dependencies, along with `libhttpserver`.
+To simplify this process, the `wheels/install_deps.sh` script can be used to build these
+dependencies locally and compile against them.
+
+.. code:: bash
+
+   ./wheels/install_deps.sh
+   pip install .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,15 @@ classifiers=[
     "Operating System :: OS Independent",
 ]
 license = {file="LICENSE"}
-dynamic = ["version"]
+dynamic = ["version", "dependencies"]
+
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
 
 [tool.setuptools_scm]
-#version_file = "py/tuber/_version.py"  # version 8.0.0 and newer
-write_to = "tuber/_version.py"  # version 7.1.0 and older
-version_scheme = "no-guess-dev"
+write_to = "tuber/_version.py"
+version_scheme = "only-version"
+local_scheme = "no-local-version"
 
 [tool.black]
 line-length = 120

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,11 @@ import pytest
 pytest_plugins = ("pytest_asyncio",)
 
 
+# Add custom orjson marker
+def pytest_configure(config):
+    config.addinivalue_line("markers", "orjson: marks tests that require server-side serialization of numpy arrays")
+
+
 # Allow test invocation to specify arguments to tuberd backend (this way, we
 # can re-use the same test machinery across different json libraries.)
 def pytest_addoption(parser):

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-
-markers =
-	orjson: marks tests that require server-side serialization of numpy arrays

--- a/tests/test.py
+++ b/tests/test.py
@@ -9,8 +9,11 @@ import pathlib
 import pytest
 import requests
 import subprocess
-import test_module as tm
-import textwrap
+
+try:
+    import test_module as tm
+except ImportError:
+    from tuber.tests import test_module as tm
 import tuber
 from tuber import codecs
 import weakref
@@ -120,11 +123,8 @@ registry = {
 def tuberd(pytestconfig):
     """Spawn (and kill) a tuberd"""
 
-    bin_dir = pathlib.Path(os.environ.get("CMAKE_BINARY_DIR", "."))
-    src_dir = pathlib.Path(os.environ.get("CMAKE_SOURCE_DIR", "."))
-
-    tuberd = bin_dir / "tuberd"
-    registry = src_dir / "tests/test.py"
+    tuberd = "tuberd"
+    registry = __file__
 
     argv = [
         f"{tuberd}",
@@ -420,13 +420,7 @@ async def test_tuberpy_module_docstrings(tuber_call, accept_types, simple):
     """Ensure docstrings in C++ methods end up in the TuberObject's __doc__ dunder."""
 
     s = await resolve("Wrapper", accept_types, simple)
-    assert (
-        s.__doc__
-        == textwrap.dedent(
-            """
-        This is the object DocString, defined in C++."""
-        ).lstrip()
-    )
+    assert s.__doc__.strip() == tm.Wrapper.__doc__.strip()
 
 
 @pytest.mark.parametrize("simple", [True, False])
@@ -436,15 +430,7 @@ async def test_tuberpy_method_docstrings(tuber_call, accept_types, simple):
     """Ensure docstrings in C++ methods end up in the TuberObject's __doc__ dunder."""
 
     s = await resolve("Wrapper", accept_types, simple)
-    assert (
-        s.increment.__doc__
-        == textwrap.dedent(
-            """
-        increment(self: test_module.Wrapper, x: List[int]) -> List[int]
-
-        A function that increments each element in its argument list."""
-        ).lstrip()
-    )
+    assert s.increment.__doc__.strip() == tm.Wrapper.increment.__doc__.strip()
 
 
 @pytest.mark.parametrize("simple", [False])

--- a/wheels/FindLibHttpServer.cmake
+++ b/wheels/FindLibHttpServer.cmake
@@ -1,0 +1,42 @@
+# - Find LibHttpServer
+
+if(LIBHTTPSERVER_INCLUDE_DIRS AND LIBHTTPSERVER_LIBRARIES)
+    set(LIBHTTPSERVER_FOUND TRUE)
+
+else(LIBHTTPSERVER_INCLUDE_DIRS AND LIBHTTPSERVER_LIBRARIES)
+    find_path(LIBHTTPSERVER_INCLUDE_DIRS httpserverpp
+      /usr/include
+      /usr/include/httpserver
+      /usr/local/include/
+      /usr/local/include/httpserver
+      )
+
+  find_library(LIBHTTPSERVER_LIBRARY NAMES httpserver
+      PATHS
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      )
+
+  find_library(LIBMICROHTTPD_LIBRARY NAMES microhttpd
+      PATHS
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      )
+
+  if(LIBHTTPSERVER_LIBRARY AND LIBMICROHTTPD_LIBRARY)
+      set(LIBHTTPSERVER_LIBRARIES "${LIBHTTPSERVER_LIBRARY};${LIBMICROHTTPD_LIBRARY}")
+  endif(LIBHTTPSERVER_LIBRARY AND LIBMICROHTTPD_LIBRARY)
+
+  if(LIBHTTPSERVER_INCLUDE_DIRS AND LIBHTTPSERVER_LIBRARIES)
+      set(LIBHTTPSERVER_FOUND TRUE)
+      message(STATUS "Found libhttpserver: ${LIBHTTPSERVER_INCLUDE_DIRS}, ${LIBHTTPSERVER_LIBRARIES}")
+  else(LIBHTTPSERVER_INCLUDE_DIRS AND LIBHTTPSERVER_LIBRARIES)
+      set(LIBHTTPSERVER_FOUND FALSE)
+    message(STATUS "libhttpserver not found.")
+  endif(LIBHTTPSERVER_INCLUDE_DIRS AND LIBHTTPSERVER_LIBRARIES)
+
+  mark_as_advanced(LIBHTTPSERVER_INCLUDE_DIRS LIBHTTPSERVER_LIBRARIES)
+
+endif(LIBHTTPSERVER_INCLUDE_DIRS AND LIBHTTPSERVER_LIBRARIES)

--- a/wheels/install_deps.sh
+++ b/wheels/install_deps.sh
@@ -2,10 +2,13 @@
 
 set -e
 
+scriptdir=$(cd `dirname $0`; pwd -P)
+echo $scriptdir
+cd $scriptdir/..
+
 [ -d deps/lib ] || (mkdir -p deps/lib && cd deps && ln -s lib lib64)
 prefix=$PWD/deps
-
-cd deps
+cd $prefix
 
 [ -e fmt-10.2.1.zip ] || wget https://github.com/fmtlib/fmt/releases/download/10.2.1/fmt-10.2.1.zip
 [ -e fmt-10.2.1 ] || unzip fmt-10.2.1.zip
@@ -14,7 +17,7 @@ cd fmt-10.2.1/build
 cmake .. -DCMAKE_INSTALL_PREFIX=$prefix -DFMT_TEST=FALSE -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE
 make
 make install
-cd -
+cd $prefix
 
 [ -e libmicrohttpd-1.0.1.tar.gz ] || wget https://github.com/Karlson2k/libmicrohttpd/releases/download/v1.0.1/libmicrohttpd-1.0.1.tar.gz
 [ -e libmicrohttpd-1.0.1 ] || tar xzf libmicrohttpd-1.0.1.tar.gz
@@ -22,21 +25,20 @@ cd libmicrohttpd-1.0.1
 ./configure --without-gnutls --enable-https=no --enable-shared=no --disable-doc --disable-examples --disable-tools --prefix=$prefix
 make
 make install
-cd -
+cd $prefix
 
 [ -e libhttpserver ] || git clone https://github.com/etr/libhttpserver.git
 cd libhttpserver
 git checkout 0.19.0
 [ -e configure ] || ./bootstrap
 [ -e build ] || mkdir build
-cd -
-cd libhttpserver/build
+cd build
 ../configure --enable-shared=no --disable-examples --prefix=$prefix CFLAGS=-I$prefix/include CXXFLAGS=-I$prefix/include LDFLAGS="-pthread -L$prefix/lib" || (
     cat config.log
     exit 1
 )
 make
 make install
-cd -
+cd $prefix
 
-cp ../wheels/FindLibHttpServer.cmake share/cmake/Modules/.
+cp $scriptdir/FindLibHttpServer.cmake $prefix/share/cmake/Modules/.


### PR DESCRIPTION
The new package workflow builds pip wheels on linux and mac Github runners any time changes are pushed to the master branch or a pull request.  Dependencies are compiled as static libraries to avoid rpath issues on installation of the tuberd binary.  Tests are integrated into each wheel and run for each operating system and python version. Github version releases trigger uploading the source distribution and all wheels to PyPI.

Notable changes include:

* Simplify versioning to only keep the version tag
* Ensure correct version number is included in sdist tarball
* Consistent discovery and linking of required libraries via both cmake and pip
* Integrate test suite into package wheel
* Manually build all dependencies as static libraries on all runners

NB: The tuberd binary must be linked against the compiled python library.  The cibuildwheel package provides a convenient way of building and testing wheels with a single action, but the manylinux image it uses for the build does not include the necessary compiled python libraries (by design), so the build process for linux has been assembled manually here.