### PR TITLE
Construct valid signatures for remote methods

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -9,6 +9,7 @@ import pathlib
 import pytest
 import requests
 import subprocess
+import inspect
 
 try:
     import test_module as tm
@@ -430,7 +431,11 @@ async def test_tuberpy_method_docstrings(tuber_call, accept_types, simple):
     """Ensure docstrings in C++ methods end up in the TuberObject's __doc__ dunder."""
 
     s = await resolve("Wrapper", accept_types, simple)
-    assert s.increment.__doc__.strip() == tm.Wrapper.increment.__doc__.strip()
+    assert s.increment.__doc__.strip() == tm.Wrapper.increment.__doc__.split("\n", 1)[-1].strip()
+
+    # check signature
+    sig = inspect.signature(s.increment)
+    assert "x" in sig.parameters
 
 
 @pytest.mark.parametrize("simple", [False])

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -82,6 +82,21 @@ def describe(registry, request):
             return result_response(attr)
 
         # Complex case: return a description of a method
-        return result_response(__doc__=inspect.getdoc(attr))
+        doc = inspect.getdoc(attr)
+        sig = None
+        try:
+            sig = str(inspect.signature(attr))
+        except:
+            # pybind docstrings include a signature as the first line
+            if doc and doc.startswith(attr.__name__ + "("):
+                if "\n" in doc:
+                    sig, doc = doc.split("\n", 1)
+                    doc = doc.strip()
+                else:
+                    sig = doc
+                    doc = None
+                sig = "(" + sig.split("(", 1)[1]
+
+        return result_response(__doc__=doc, __signature__=sig)
 
     return error_response(f"Invalid request (object={objname}, method={methodname}, property={propertyname})")


### PR DESCRIPTION
This allows client-side inspection of argument names, types and default values.