### PR TITLE
Migrate request handling to python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ add_test(NAME test-native-json
 
 add_test(NAME test-orjson-fastpath
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-	COMMAND tests/test.py --orjson-with-numpy)
+	COMMAND tests/test.py --orjson)
 
 set_tests_properties(test-native-json test-orjson-fastpath
 	PROPERTIES ENVIRONMENT "CMAKE_TEST=1;PATH=${CMAKE_BINARY_DIR}:$ENV{PATH};PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_SOURCE_DIR}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,5 +39,5 @@ line-length = 120
 before-all = "./wheels/install_deps.sh"
 test-command = [
     "pytest -sv {project}/tests/test.py --import-mode append",
-    "pytest -sv {project}/tests/test.py --import-mode append --orjson-with-numpy",
+    "pytest -sv {project}/tests/test.py --import-mode append --orjson",
 ]

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1,19 +1,15 @@
-#include <chrono>
 #include <csignal>
 #include <filesystem>
 #include <iostream>
 #include <map>
-#include <queue>
 #include <sstream>
 #include <string>
-#include <vector>
 
 #include <httpserver.hpp>
 #include <httpserver/http_utils.hpp>
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <pybind11/eval.h>
 
 #include <fmt/format.h>
 
@@ -40,58 +36,21 @@ struct fmt::formatter<T, std::enable_if_t<std::is_base_of<py::object, T>::value,
  * about symbol visibility here, we follow its lead to squash warnings. */
 #define DLL_LOCAL __attribute__((visibility("hidden")))
 
-struct DLL_LOCAL Codec {
-	using loads_t = std::function<py::object(std::string)>;
-	using dumps_t = std::function<std::string(py::object)>;
-
-	loads_t loads;
-	dumps_t dumps;
-};
-
 /* Verbosity is expressed as a bit mask:
  *     0: none (default)
  *     1: report unexpected or unusual cases
  *     2: very noisy
- *     4: performance profiling
  */
 static enum class Verbose {
 	NONE = 0,	/* default */
 	UNEXPECTED = 1,	/* report unexected or unusual cases */
 	NOISY = 2,	/* message onslaught */
-	TIMING = 4,
 } verbose;
 
 /* Operators for log levels */
 inline constexpr int operator&(Verbose const& x, Verbose const& y) {
 	return static_cast<int>(x) & static_cast<int>(y);
 }
-
-/* Needed to assign verbosity from program options. No validation occurs here. */
-std::istream& operator>>(std::istream& in, Verbose& v) {
-	int token;
-	in >> token;
-	v = static_cast<Verbose>(token);
-	return in;
-}
-
-class timed_scope {
-	public:
-		timed_scope(std::string const& msg) : msg(msg) {
-			if(verbose & Verbose::TIMING)
-				t = std::chrono::steady_clock::now();
-		}
-		~timed_scope() {
-			if(verbose & Verbose::TIMING) {
-				std::chrono::duration dt = std::chrono::steady_clock::now() - t;
-				fmt::print(stderr, "{}: {}ms\n",
-						msg,
-						std::chrono::duration_cast<std::chrono::milliseconds>(dt).count());
-			}
-		}
-	private:
-		std::string msg;
-		std::chrono::time_point<std::chrono::steady_clock> t;
-};
 
 /* MIME types */
 static const std::string MIME_JSON="application/json";
@@ -126,143 +85,14 @@ static const std::map<std::string, std::string> MIME_TYPES = {
 	{".pdf",   "application/pdf"},
 };
 
-static inline py::object error_response(std::string const& msg) {
-	return py::dict("error"_a=py::dict("message"_a=msg));
-}
-
-std::vector<std::string> warning_list;
-static void showwarning(py::object message,
-			py::object category,
-			py::object filename,
-			py::object lineno,
-			py::object file,
-			py::object line) {
-
-	if(verbose & Verbose::NOISY)
-		fmt::print(stderr, "... captured warning '{}'\n", py::str(message).cast<std::string>());
-
-	warning_list.push_back(py::str(message).cast<std::string>());
-}
-
-static std::vector<std::string> parseCommaSepList(std::string_view rawl){
-	//this makes no special effort to be efficient; it just copies strings all over
-	std::istringstream is(std::string{rawl});
-	std::vector<std::string> results;
-	std::string item;
-	while(is >> item){
-		if(item.empty())
-			continue;
-		else if(item.back()==',')
-			results.push_back(item.substr(0,item.size()-1));
-		else
-			results.push_back(item);
-	}
-	return results;
-}
-
-static py::dict tuber_server_invoke(py::dict &registry,
-		py::dict const& call,
-		py::object const& describe,
-		Codec::loads_t const& loads,
-		Codec::dumps_t const& dumps) {
-
-	timed_scope ts(__func__);
-
-	/* Fast path: function calls */
-	if(call.contains("object") && call.contains("method")) {
-
-		std::string oname = call["object"].cast<std::string>();
-		std::string mname = call["method"].cast<std::string>();
-
-		/* Populate python_args */
-		py::list python_args;
-		if(call.contains("args")) {
-			try {
-				python_args = call["args"];
-			} catch(py::error_already_set const&) {
-				return error_response("'args' wasn't an array.");
-			}
-		}
-
-		/* Populate python_kwargs */
-		py::dict python_kwargs;
-		if(call.contains("kwargs")) {
-			try {
-				python_kwargs = call["kwargs"];
-			} catch(py::error_already_set const&) {
-				return error_response("'kwargs' wasn't an object.");
-			}
-		}
-
-		/* Look up object */
-		py::object o = registry[oname.c_str()];
-		if(!o)
-			return error_response("Object not found in registry.");
-
-		/* Look up method */
-		py::object m = o.attr(mname.c_str());
-		if(!m)
-			return error_response("Method not found in object.");
-
-		if(verbose & Verbose::NOISY)
-			fmt::print(stderr, "Dispatch: {}::{}(*{}, **{})...\n",
-					oname, mname,
-					python_args,
-					python_kwargs);
-
-		/* Dispatch to Python - failures emerge as exceptions */
-		timed_scope ts("Python dispatch");
-		py::object response = py::none();
-		try {
-			response = py::dict("result"_a=m(*python_args, **python_kwargs));
-		} catch(std::exception &e) {
-			response = error_response(e.what());
-		}
-
-		/* Capture warnings, if any */
-		if(!warning_list.empty()) {
-			response["warnings"] = warning_list;
-			warning_list.clear();
-		}
-
-		if(verbose & Verbose::NOISY)
-			fmt::print(stderr, "... response was {}\n", dumps(response));
-
-		return response;
-	}
-
-	if(verbose & Verbose::NOISY)
-		fmt::print(stderr, "Delegating json {} to describe() slowpath.\n", call);
-
-	/* Slow path: object metadata, properties */
-	return describe(registry, call);
-}
-
 /* Responder for tuber resources exported via JSON.
  *
  * This code serves both "hot" (method call) and "cold" paths (metadata, cached
- * property fetches). Hot paths are coded in c++. Cold paths are coded in
- * Python (in the preamble). */
+ * property fetches). All paths are coded in Python (in the tuber.server package),
+ * with hot path dispatch to C++ handled by the user. */
 class DLL_LOCAL tuber_resource : public http_resource {
 	public:
-		using CodecMap = std::map<std::string, Codec>;
-		tuber_resource(py::dict const& reg, const CodecMap& codecs, py::object const& describe) :
-			reg(reg), codecs(codecs), describe(describe) {};
-
-		std::string determineResponseFormat(std::string_view accept, std::string_view requestFormat) {
-			if (accept.empty()) //If nothing specified, use what the client used
-				return std::string(requestFormat);
-			auto acceptedV = parseCommaSepList(accept);
-			for (const auto& accepted : acceptedV) {
-				if (codecs.count(accepted))
-					return std::string(accepted);
-			}
-			// If the client claims to accept anything, pick arbitrarily
-			if(std::find(acceptedV.begin(),acceptedV.end(),"*/*")!=acceptedV.end()
-			   || std::find(acceptedV.begin(),acceptedV.end(),"application/*")!=acceptedV.end())
-				return codecs.cbegin()->first;
-			throw std::runtime_error(fmt::format("Not able to encode any media type matching {}", accept));
-		}
+		tuber_resource(py::object const& handler) : handler(handler) {};
 
 		std::shared_ptr<http_response> render(const http_request& req) {
 			/* Acquire the GIL. This makes us thread-safe -
@@ -272,121 +102,15 @@ class DLL_LOCAL tuber_resource : public http_resource {
 			 */
 			py::gil_scoped_acquire acquire;
 
-			CodecMap::const_iterator responseCodecIt;
-			std::string responseFormat;
+			py::tuple resp = handler(req.get_content(), req.get_headers());
 
-			// We assume that this cannot fail because JSON must always be available
-			auto setDefaultFormat = [&](){
-				responseFormat = MIME_JSON;
-				responseCodecIt = codecs.find(responseFormat);
-			};
-			setDefaultFormat();
-			auto encodeResponse = [&responseCodecIt](py::object value){
-				return responseCodecIt->second.dumps(value);
-			};
+			std::string responseFormat = resp[0].cast<std::string>();
+			std::string response = resp[1].cast<std::string>();
 
-			try {
-				if(verbose & Verbose::NOISY)
-					fmt::print(stderr, "Request: {}\n", req.get_content());
-
-				/* Figure out formats for request and response */
-				std::string requestFormat = std::string(req.get_header("Content-Type"));
-				if (requestFormat.empty()) // assume JSON if unspecified
-					requestFormat = MIME_JSON;
-				auto requestCodecIt = codecs.find(requestFormat);
-				if (requestCodecIt == codecs.end()){
-					std::string message = fmt::format("Not able to decode media type {}", requestFormat);
-					if(verbose & Verbose::NOISY)
-						fmt::print("Exception path response: {}\n", message);
-					return std::make_shared<string_response>(encodeResponse(error_response(message)), http::http_utils::http_ok, responseFormat);
-				}
-
-				responseFormat = determineResponseFormat(req.get_header("Accept"), requestFormat);
-				responseCodecIt = codecs.find(responseFormat);
-				if (responseCodecIt == codecs.end()){
-					std::string message = fmt::format("Not able to encode media type {}", responseFormat);
-					if(verbose & Verbose::NOISY)
-						fmt::print("Exception path response: {}\n", message);
-					setDefaultFormat();
-					return std::make_shared<string_response>(encodeResponse(error_response(message)), http::http_utils::http_ok, responseFormat);
-				}
-
-				auto xopts = parseCommaSepList(req.get_header("X-Tuber-Options"));
-				bool continue_on_error = false;
-				if (xopts.size() > 0) {
-					continue_on_error = std::find(xopts.begin(), xopts.end(), "continue-on-error") != xopts.end();
-				}
-
-				/* Parse request */
-				std::string content(req.get_content());
-				py::object request_obj = requestCodecIt->second.loads(content);
-
-				if(py::isinstance<py::dict>(request_obj)) {
-					/* Simple JSON object - invoke it and return the results. */
-					py::object result;
-					try {
-						result = tuber_server_invoke(reg, request_obj, describe, responseCodecIt->second.loads, responseCodecIt->second.dumps);
-					} catch(std::exception &e) {
-						result = error_response(e.what());
-						if(verbose & Verbose::NOISY)
-							fmt::print("Exception path response: {}\n", e.what());
-					}
-					return std::shared_ptr<http_response>(new string_response(encodeResponse(result), http::http_utils::http_ok, responseFormat));
-
-				} else if(py::isinstance<py::list>(request_obj)) {
-					py::list request_list = request_obj;
-
-					/* Array of sub-requests. Error-handling semantics are
-					 * embedded here: if something goes wrong, we do not
-					 * execute subsequent calls but /do/ pad the results
-					 * list to have the expected size. */
-					py::list result(py::len(request_list));
-
-					bool early_bail = false;
-					for(size_t i=0; i<result.size(); i++) {
-						/* If something went wrong earlier in the loop, don't execute anything else. */
-						if(early_bail) {
-							result[i] = error_response("Something went wrong in a preceding call.");
-							continue;
-						}
-
-						try {
-							result[i] = tuber_server_invoke(reg, request_list[i], describe, responseCodecIt->second.loads, responseCodecIt->second.dumps);
-						} catch(std::exception &e) {
-							/* Indicates an internal error - this does not normally happen */
-							result[i] = error_response(e.what());
-							if (!continue_on_error)
-								early_bail = true;
-						}
-
-						if(result[i].contains("error") && !continue_on_error) {
-							/* Indicates client code flagged an error - this is a nominal code path */
-							early_bail = true;
-						}
-					}
-
-					timed_scope ts("Happy-path serialization");
-
-					/* FIXME: serialization failure in an array call returns with an object structure! */
-					std::string encoded_result = encodeResponse(result);
-					return std::shared_ptr<http_response>(new string_response(encoded_result, http::http_utils::http_ok, responseFormat));
-				}
-				else {
-					std::string error = encodeResponse(error_response("Unexpected type in request."));
-					return std::shared_ptr<http_response>(new string_response(error, http::http_utils::http_ok, responseFormat));
-				}
-			} catch(std::exception const& e) {
-				if(verbose & Verbose::UNEXPECTED)
-					fmt::print(stderr, "Unhappy-path response {}\n", e.what());
-
-				std::string error = encodeResponse(error_response(e.what()));
-				return std::shared_ptr<http_response>(new string_response(error, http::http_utils::http_ok, responseFormat));
-			}
+			return std::make_shared<string_response>(response, http::http_utils::http_ok, responseFormat);
 		}
 	private:
-		py::dict reg;
-		const CodecMap& codecs;
-		py::object describe;
+		py::object handler;
 };
 
 /* Responder for files served out of the local filesystem.
@@ -420,7 +144,7 @@ class DLL_LOCAL file_resource : public http_resource {
 				if(verbose & Verbose::UNEXPECTED)
 					fmt::print(stderr, "Unable or unwilling to serve missing or non-file resource {}\n", path.string());
 
-				return std::shared_ptr<http_response>(new string_response("No such file or directory.\n", http::http_utils::http_not_found));
+				return std::make_shared<string_response>("No such file or directory.\n", http::http_utils::http_not_found);
 			}
 
 			/* Figure out a MIME type to use */
@@ -433,7 +157,7 @@ class DLL_LOCAL file_resource : public http_resource {
 				fmt::print(stderr, "Serving {} with {} using MIME type {}\n", req.get_path(), path.string(), mime_type);
 
 			/* Construct response and return it */
-			auto response = std::shared_ptr<file_response>(new file_response(path.string(), http::http_utils::http_ok, mime_type));
+			auto response = std::make_shared<file_response>(path.string(), http::http_utils::http_ok, mime_type);
 			response->with_header(http::http_utils::http_header_cache_control, fmt::format("max-age={}", max_age));
 			return response;
 		}
@@ -449,77 +173,17 @@ static void sigint(int signo) {
 		ws->stop();
 }
 
-static void
-run_server(const std::string &registry="/usr/share/tuberd/registry.py",
-	   const std::string &json="json",
-	   bool orjson_with_numpy=false,
-	   int port=80,
-	   const std::string &webroot="/var/www/",
-	   int max_age=3600,
-	   int verbose_level=0)
+void run_server(py::object handler, int port=80, const std::string &webroot="/var/www", int max_age=3600, int verbose_level=0)
 {
 	/*
 	 * Parse command-line arguments
 	 */
 
-	std::string json_module = json;
 	verbose = static_cast<Verbose>(verbose_level);
 
-	/*
-	 * Initialize Python runtime
-	 */
-
-	/* Indicate to anyone who cares that we're running server-side */
-	setenv("TUBER_SERVER", "1", 1);
-
-	/* By default, capture warnings */
-	py::module warnings = py::module::import("warnings");
-	warnings.attr("showwarning") = py::cpp_function(showwarning);
-
-	/* Learn how the Python half lives */
-	py::module tuber = py::module::import("tuber.server");
-
-	/* Load indicated Python initialization scripts */
-	py::eval_file(registry);
-
-	std::map<std::string, Codec> codecs;
-	py::dict py_codecs;
-
-	py_codecs = tuber.attr("Codecs");
-	py::object py_describe = tuber.attr("describe");
-
-	/* Import JSON dumps function so we can use it */
-	if(orjson_with_numpy)
-		json_module = "orjson";
-
-	/* Import Python loads/dumps */
-	py::object py_codec = py_codecs[json_module.c_str()];
-	py::object py_loads = py_codec.attr("decode");
-	py::object py_dumps = py_codec.attr("encode");
-
-	Codec::loads_t json_loads = [py_loads](std::string s) { return py_loads(s); };
-	Codec::dumps_t json_dumps = [py_dumps](py::object o) {
-		return py_dumps(o).cast<std::string>();
-	};
-	codecs.emplace(MIME_JSON, Codec{json_loads, json_dumps});
-
-	try{
-		py::object py_codec = py_codecs["cbor"];
-		py::object py_loads = py_codec.attr("decode");
-		py::object py_dumps = py_codec.attr("encode");
-
-		Codec::loads_t cbor_loads = [py_loads](std::string s) { return py_loads(s); };
-		Codec::dumps_t cbor_dumps = [py_dumps](py::object o) {
-			return py_dumps(o).cast<std::string>();
-		};
-		codecs.emplace(MIME_CBOR, Codec{cbor_loads, cbor_dumps});
-	} catch(std::exception const& e) {
-		if(verbose & Verbose::NOISY)
-			fmt::print(stderr, "Could not import cbor2, CBOR will not be available: {}\n", e.what());
-	}
-
-	/* Create a registry */
-	py::dict reg = py::eval("registry");
+	/* Can only run one server at a time */
+	if (ws)
+		throw std::runtime_error("Tuber server already running!");
 
 	/*
 	 * Start webserver
@@ -532,7 +196,7 @@ run_server(const std::string &registry="/usr/share/tuberd/registry.py",
 	std::signal(SIGINT, &sigint);
 
 	/* Set up /tuber endpoint */
-	tr = std::make_unique<tuber_resource>(reg, codecs, py_describe);
+	tr = std::make_unique<tuber_resource>(handler);
 	tr->disallow_all();
 	tr->set_allowing(MHD_HTTP_METHOD_POST, true);
 	ws->register_resource("/tuber", tr.get());
@@ -566,12 +230,10 @@ PYBIND11_MODULE(_tuber_runtime, m) {
 	    "endpoint and a /tuber endpoint that parses requests via a handler function,\n"
 	    "and runs the server until an interrupt is signaled.\n\n"
 	    "Arguments\n---------\n"
-	    "registry : str\n"
-	    "    Location of registry Python code\n"
-	    "json_module : str\n"
-	    "    Python JSON module to use for serialization/deserialization\n"
-	    "orjson_with_numpy : bool\n"
-	    "    Use ORJSON module with fast NumPy serialization support\n"
+	    "handler : callable\n"
+	    "    Callable that takes an encoded request string and header dictionary arguments,\n"
+	    "    and returns the response format and encoded response string.  Signature:\n"
+	    "    ``function(request: str, headers: dict) -> tuple[str, str]``\n"
 	    "port : int\n"
 	    "    Port on which to run the server\n"
 	    "webroot : str\n"
@@ -579,8 +241,7 @@ PYBIND11_MODULE(_tuber_runtime, m) {
 	    "max_age : int\n"
 	    "    Maximum cache residency for static (file) assets\n"
 	    "verbose : int\n"
-	    "    Verbosity level (0-7)\n",
-	    py::arg("registry")="/usr/share/tuberd/registry.py", py::arg("json_module")="json",
-	    py::arg("orjson_with_numpy")=false, py::arg("port")=80, py::arg("webroot")="/var/www/",
+	    "    Verbosity level (0-2)\n",
+	    py::arg("handler"), py::arg("port")=80, py::arg("webroot")="/var/www/",
 	    py::arg("max_age")=3600, py::arg("verbose")=0);
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,15 +14,15 @@ def pytest_addoption(parser):
     # Create a pass-through path for tuberd options (e.g. for verbosity)
     parser.addoption("--tuberd-option", action="append", default=[])
 
-    # The "--orjson-with-numpy" option is handled as a special case because it
+    # The "--orjson" option is handled as a special case because it
     # changes test behaviour.
-    parser.addoption("--orjson-with-numpy", action="store_true", default=False)
+    parser.addoption("--orjson", action="store_true", default=False)
 
 
 # Some tests require orjson - the following skips them unless we're in
-# --orjson-with-numpy mode.
+# --orjson mode.
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("orjson_with_numpy"):
+    if config.getoption("orjson"):
         return
 
     for item in items:

--- a/tests/test.py
+++ b/tests/test.py
@@ -139,12 +139,12 @@ def tuberd(pytestconfig):
 
     argv.extend(pytestconfig.getoption("tuberd_option"))
 
-    if pytestconfig.getoption("orjson_with_numpy"):
+    if pytestconfig.getoption("orjson"):
         # If we can't import orjson here, it's presumably missing from the
         # tuberd execution environment as well - in which case, we should skip
         # the test.
         pytest.importorskip("orjson")
-        argv.append("--orjson-with-numpy")
+        argv.extend(["--json", "orjson"])
 
     s = subprocess.Popen(argv)
     yield s

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -328,11 +328,6 @@ def main():
         dest="json_module",
         help="Python JSON module to use for serialization/deserialization",
     )
-    P.add_argument(
-        "--orjson-with-numpy",
-        action="store_true",
-        help="Use ORJSON module with fast NumPy serialization support",
-    )
     P.add_argument("-p", "--port", default=80, type=int, help="Port")
     P.add_argument("-w", "--webroot", default="/var/www/", help="Location to serve static content")
     P.add_argument(
@@ -355,8 +350,6 @@ def main():
         from ._tuber_runtime import run_server
 
     # prepare handler
-    if args.orjson_with_numpy:
-        args.json_module = "orjson"
     handler = RequestHandler(args.registry, args.json_module)
 
     # run

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -1,8 +1,8 @@
 import inspect
+import warnings
 
-from .codecs import Codecs
 
-
+# request handling
 def result_response(arg=None, **kwargs):
     """
     Return a valid result response to the server to be parsed by the client.
@@ -16,6 +16,8 @@ def error_response(message):
     """
     Return an error message to the server to be raised by the client.
     """
+    if isinstance(message, Exception):
+        message = f"{message.__class__.__name__}: {str(message)}"
     return {"error": {"message": message}}
 
 
@@ -102,6 +104,208 @@ def describe(registry, request):
     return error_response(f"Invalid request (object={objname}, method={methodname}, property={propertyname})")
 
 
+def invoke(registry, request):
+    """
+    Tuber command path
+
+    This is invoked with a "request" object with any of the following combinations of keys:
+
+    - A registry descriptor (no "object" or "method" or "property")
+    - An object descriptor ("object" but no "method" or "property")
+    - A method descriptor ("object" and a "property" corresponding to a method)
+    - A property descriptor ("object" and a "property" that is static data)
+    - A method call ("object" and "method", with optional "args" and/or "kwargs")
+    """
+
+    try:
+        if not ("object" in request and "method" in request):
+            return describe(registry, request)
+
+        objname = request["object"]
+        methodname = request["method"]
+
+        try:
+            obj = registry[objname]
+        except KeyError:
+            raise AttributeError(f"Object '{objname}' not found in registry.")
+
+        method = getattr(obj, methodname)
+
+        args = request.get("args", [])
+        if not isinstance(args, list):
+            raise TypeError(f"Argument 'args' for method {objname}.{methodname} must be a list.")
+
+        kwargs = request.get("kwargs", {})
+        if not isinstance(kwargs, dict):
+            raise TypeError(f"Argument 'kwargs' for method {objname}.{methodname} must be a dict.")
+
+    except Exception as e:
+        return error_response(e)
+
+    with warnings.catch_warnings(record=True) as wlist:
+        try:
+            response = result_response(method(*args, **kwargs))
+        except Exception as e:
+            response = error_response(e)
+
+        if len(wlist):
+            response["warnings"] = [str(w.message) for w in wlist]
+
+    return response
+
+
+class RequestHandler:
+    """
+    Tuber server request handler.
+    """
+
+    def __init__(self, reg, json_module="json", default_format="application/json"):
+        """
+        Arguments
+        ---------
+        reg : dict or str
+            Dictionary of user-defined objects with properties and methods,
+            or a path to a python file that can be executed to load a registry
+            dictionary into the current namespace.
+        json_module : str
+            Python package to use for encoding and decoding JSON requests.
+        default_format : str
+            Default encoding format to assume for requests and responses.
+        """
+        # load the registry file and make sure it contains a registry dictionary
+        if isinstance(reg, str):
+            code = compile(open(reg, "r").read(), reg, "exec")
+            exec(code, globals())
+            assert isinstance(registry, dict), "Invalid registry"
+            reg = registry
+
+        self.registry = reg
+        self.codecs = {}
+
+        # populate codecs
+        from .codecs import Codecs
+
+        try:
+            self.codecs["application/json"] = Codecs[json_module]
+        except Exception as e:
+            raise RuntimeError(f"Unable to import {json_module} codec ({str(e)})")
+
+        try:
+            self.codecs["application/cbor"] = Codecs["cbor"]
+        except Exception as e:
+            warnings.warn(f"Unable to import cbor codec ({str(e)})")
+
+        assert default_format in self.codecs, f"Missing codec for {default_format}"
+        self.default_format = default_format
+
+    def encode(self, data, fmt=None):
+        """
+        Encode the input data using the requested format.
+
+        Returns the response format and the encoded data.
+        """
+        if fmt is None:
+            fmt = self.default_format
+        return fmt, self.codecs[fmt].encode(data)
+
+    def decode(self, data, fmt=None):
+        """
+        Decode the input data using the requested format.
+
+        Returns the decoded data.
+        """
+        if fmt is None:
+            fmt = self.default_format
+        return self.codecs[fmt].decode(data)
+
+    def handle(self, request, headers):
+        """
+        Handle the input request from the server.
+
+        Arguments
+        ---------
+        request : str
+            Encoded request string.
+        headers : dict
+            Dictionary of headers from the posted request.  Valid keys are:
+
+                Content-Type: a string containing a valid request format type,
+                    e.g. "application/json" or "application/cbor"
+                Accept: a string containing a valid response format type,
+                    e.g. "application/json", "application/cbor" or "*/*"
+                X-Tuber-Options: a configuration option for the handler,
+                    e.g. "continue-on-error"
+
+        Returns
+        -------
+        response_format : str
+            The format into which the response is encoded
+        response : str
+            The encoded response string
+        """
+        request_format = response_format = self.default_format
+        encode = lambda d: self.encode(d, response_format)
+
+        try:
+            # parse request format
+            content_type = headers.get("Content-Type", request_format)
+            if content_type not in self.codecs:
+                raise ValueError(f"Not able to decode media type {content_type}")
+            # Default to using the same response format as the request
+            request_format = response_format = content_type
+
+            # parse response format
+            if "Accept" in headers:
+                accept_types = [v.strip() for v in headers["Accept"].split(",")]
+                if "*/*" in accept_types or "application/*" in accept_types:
+                    response_format = request_format
+                else:
+                    for t in accept_types:
+                        if t in self.codecs:
+                            response_format = t
+                            break
+                    else:
+                        msg = f"Not able to encode any media type matching {headers['Accept']}"
+                        raise ValueError(msg)
+
+            # decode request
+            request_obj = self.decode(request, request_format)
+
+            # parse single request
+            if isinstance(request_obj, dict):
+                result = invoke(self.registry, request_obj)
+                return encode(result)
+
+            if not isinstance(request_obj, list):
+                raise TypeError("Unexpected type in request")
+
+            # optionally allow requests to continue to the next item if an error
+            # is raised for any request in the list
+            xopts = [v.strip() for v in headers.get("X-Tuber-Options", "").split(",")]
+            continue_on_error = "continue-on-error" in xopts
+
+            # parse sequence of requests
+            results = [None for r in request_obj]
+            early_bail = False
+            for i, r in enumerate(request_obj):
+                if early_bail:
+                    results[i] = error_response("Something went wrong in a preceding call")
+                    continue
+
+                results[i] = invoke(self.registry, r)
+
+                if "error" in results[i] and not continue_on_error:
+                    early_bail = True
+
+            return encode(results)
+
+        except Exception as e:
+            return encode(error_response(e))
+
+    def __call__(self, *args, **kwargs):
+        return self.handle(*args, **kwargs)
+
+
 def main():
     """
     Server entry point
@@ -141,14 +345,28 @@ def main():
     P.add_argument("-v", "--verbose", type=int, default=0)
     args = P.parse_args()
 
+    # setup environment
+    os.environ["TUBER_SERVER"] = "1"
+
     # import runtime
     if os.getenv("CMAKE_TEST"):
         from _tuber_runtime import run_server
     else:
         from ._tuber_runtime import run_server
 
+    # prepare handler
+    if args.orjson_with_numpy:
+        args.json_module = "orjson"
+    handler = RequestHandler(args.registry, args.json_module)
+
     # run
-    run_server(**vars(args))
+    run_server(
+        handler,
+        port=args.port,
+        webroot=args.webroot,
+        max_age=args.max_age,
+        verbose=args.verbose,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This avoids having wrestle with codecs and python objects in the C++ code, and significantly reduces the overhead for replacing the server with some other implementation in the future.