### PR TITLE
Dynamic object attributes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,10 @@ add_test(NAME test-orjson-fastpath
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 	COMMAND tests/test.py --orjson)
 
+add_test(NAME test-doctests
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	COMMAND python3 -m pytest tuber --doctest-modules)
+
 set_tests_properties(test-native-json test-orjson-fastpath
 	PROPERTIES ENVIRONMENT "CMAKE_TEST=1;PATH=${CMAKE_BINARY_DIR}:$ENV{PATH};PYTHONPATH=${CMAKE_BINARY_DIR}:${CMAKE_SOURCE_DIR}")
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -226,7 +226,7 @@ container_success = Succeeded(
     __doc__=TuberContainer.__doc__.strip(),
     methods=["resolve"],
     objects=[],
-    properties=["_tuber_container"],
+    properties=[],
 )
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -858,6 +858,32 @@ async def test_tuberpy_container_context(tuber_call, accept_types, simple):
 @pytest.mark.parametrize("simple", [True, False])
 @pytest.mark.parametrize("accept_types", ACCEPT_TYPES)
 @pytest.mark.asyncio
+async def test_tuberpy_container_property_context(tuber_call, accept_types, simple):
+    """Ensure methods of container objects work in contexts"""
+    s = await resolve("ObjectWithContainerProperties", accept_types=accept_types, simple=simple)
+
+    r1 = s.method_objects["a"].method()
+    if not simple:
+        r1 = await r1
+    assert r1 == "expected return value"
+
+    assert s.property_objects[0].PROPERTY == "expected property value"
+
+    if simple:
+        with s.tuber_context() as ctx:
+            ctx.method_objects["a"].method()
+            r2 = ctx()[0]
+    else:
+        async with s.tuber_context() as ctx:
+            r2 = ctx.method_objects["a"].method()
+        r2 = await r2
+
+    assert r2 == "expected return value"
+
+
+@pytest.mark.parametrize("simple", [True, False])
+@pytest.mark.parametrize("accept_types", ACCEPT_TYPES)
+@pytest.mark.asyncio
 async def test_tuberpy_container_properties(tuber_call, accept_types, simple):
     """Collect properties and method calls for container objects"""
     s = await resolve(accept_types=accept_types, simple=simple)

--- a/tests/test.py
+++ b/tests/test.py
@@ -224,7 +224,7 @@ def Failed(warnings=None, **kwargs):
 
 container_success = Succeeded(
     __doc__=TuberContainer.__doc__.strip(),
-    methods=["resolve"],
+    methods=["tuber_call", "tuber_meta"],
     objects=[],
     properties=[],
 )
@@ -899,5 +899,4 @@ async def test_tuberpy_container_properties(tuber_call, accept_types, simple):
         r2 = await r2
 
     assert len(r2) == len(mobjs)
-    assert list(r2.keys()) == list(mobjs.keys())
-    assert all([x == "expected return value" for x in r2.values()])
+    assert all([x == "expected return value" for x in r2])

--- a/tests/test.py
+++ b/tests/test.py
@@ -223,10 +223,7 @@ def Failed(warnings=None, **kwargs):
 
 
 container_success = Succeeded(
-    __doc__=TuberContainer.__doc__.strip(),
-    methods=["tuber_call", "tuber_meta"],
-    objects=[],
-    properties=[],
+    __doc__=TuberContainer.__doc__.strip(), methods=["tuber_call", "tuber_meta"], properties=[]
 )
 
 
@@ -236,29 +233,25 @@ def test_empty_request_array(tuber_call):
 
 def test_describe(tuber_call):
     assert tuber_call(json={}) == Succeeded(objects=list(registry))
-    assert tuber_call(object="ObjectWithPrivateMethod") == Succeeded(
-        __doc__=None, methods=[], objects=[], properties=[]
-    )
+    assert tuber_call(object="ObjectWithPrivateMethod") == Succeeded(__doc__=None, methods=[], properties=[])
 
     assert tuber_call(object="ObjectWithContainerProperties", property="property_objects") == container_success
     assert tuber_call(object="ObjectWithContainerProperties", property="method_objects") == container_success
     assert tuber_call(object="ObjectWithContainerProperties.property_objects[0]") == Succeeded(
-        __doc__=None, methods=[], objects=[], properties=["PROPERTY"]
+        __doc__=None, methods=[], properties=["PROPERTY"]
     )
     assert tuber_call(object='ObjectWithContainerProperties.method_objects["a"]') == Succeeded(
-        __doc__=None, methods=["method"], objects=[], properties=[]
+        __doc__=None, methods=["method"], properties=[]
     )
 
     assert tuber_call(object="ObjectList") == container_success
     assert tuber_call(object="ObjectListList[0]") == container_success
     assert tuber_call(object="ObjectDict") == container_success
-    assert tuber_call(object='ObjectDict["a"]') == Succeeded(
-        __doc__=None, methods=[], objects=["method_objects", "property_objects"], properties=[]
-    )
+    assert tuber_call(object='ObjectDict["a"]') == Succeeded(__doc__=None, methods=[], properties=[])
 
 
 def test_fetch_null_metadata(tuber_call):
-    assert tuber_call(object="NullObject") == Succeeded(__doc__=None, methods=[], objects=[], properties=[])
+    assert tuber_call(object="NullObject") == Succeeded(__doc__=None, methods=[], properties=[])
 
 
 def test_call_nonexistent_object(tuber_call):

--- a/tests/test.py
+++ b/tests/test.py
@@ -236,18 +236,19 @@ def test_describe(tuber_call):
     assert tuber_call(object="ObjectWithPrivateMethod") == Succeeded(__doc__=None, methods=[], properties=[])
 
     assert tuber_call(object="ObjectWithContainerProperties", property="property_objects") == container_success
+    assert tuber_call(object=["ObjectWithContainerProperties", "property_objects"]) == container_success
     assert tuber_call(object="ObjectWithContainerProperties", property="method_objects") == container_success
-    assert tuber_call(object="ObjectWithContainerProperties.property_objects[0]") == Succeeded(
+    assert tuber_call(object=["ObjectWithContainerProperties", ("property_objects", 0)]) == Succeeded(
         __doc__=None, methods=[], properties=["PROPERTY"]
     )
-    assert tuber_call(object='ObjectWithContainerProperties.method_objects["a"]') == Succeeded(
+    assert tuber_call(object=["ObjectWithContainerProperties", ("method_objects", "a")]) == Succeeded(
         __doc__=None, methods=["method"], properties=[]
     )
 
     assert tuber_call(object="ObjectList") == container_success
-    assert tuber_call(object="ObjectListList[0]") == container_success
+    assert tuber_call(object=[("ObjectListList", 0)]) == container_success
     assert tuber_call(object="ObjectDict") == container_success
-    assert tuber_call(object='ObjectDict["a"]') == Succeeded(__doc__=None, methods=[], properties=[])
+    assert tuber_call(object=[("ObjectDict", "a")]) == Succeeded(__doc__=None, methods=[], properties=[])
 
 
 def test_fetch_null_metadata(tuber_call):
@@ -295,17 +296,19 @@ def test_function_types_with_correct_argument_types(tuber_call):
 
 
 def test_container_properties(tuber_call):
-    assert tuber_call(object="ObjectWithContainerProperties.property_objects[0]", property="PROPERTY") == Succeeded(
-        "expected property value"
-    )
-    assert tuber_call(object='ObjectWithContainerProperties.method_objects["a"]', method="method") == Succeeded(
+    assert tuber_call(
+        object=["ObjectWithContainerProperties", ("property_objects", 0)], property="PROPERTY"
+    ) == Succeeded("expected property value")
+    assert tuber_call(object=["ObjectWithContainerProperties", ("method_objects", "a")], method="method") == Succeeded(
         "expected return value"
     )
-    assert tuber_call(object="ObjectList[0].method_objects['a']", method="method") == Succeeded("expected return value")
-    assert tuber_call(object='ObjectDict["a"].property_objects[0]', property="PROPERTY") == Succeeded(
+    assert tuber_call(object=[("ObjectList", 0), ("method_objects", "a")], method="method") == Succeeded(
+        "expected return value"
+    )
+    assert tuber_call(object=[("ObjectDict", "a"), ("property_objects", 0)], property="PROPERTY") == Succeeded(
         "expected property value"
     )
-    assert tuber_call(object="ObjectListList[1][0].method_objects['a']", method="method") == Succeeded(
+    assert tuber_call(object=[("ObjectListList", 1, 0), ("method_objects", "a")], method="method") == Succeeded(
         "expected return value"
     )
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -15,7 +15,7 @@ if os.getenv("CMAKE_TEST"):
 else:
     from tuber.tests import test_module as tm
 
-from tuber.server import TuberContainer
+from tuber.server import TuberContainer, TuberArray
 
 
 # REGISTRY DEFINITIONS
@@ -42,8 +42,8 @@ class ObjectWithPrivateMethod:
 
 
 class ObjectWithContainerProperties:
-    property_objects = TuberContainer([ObjectWithProperty(), ObjectWithProperty()])
-    method_objects = TuberContainer({"a": ObjectWithMethod(), "b": ObjectWithMethod()})
+    property_objects = TuberArray([ObjectWithProperty(), ObjectWithProperty()])
+    method_objects = TuberArray({"a": ObjectWithMethod(), "b": ObjectWithMethod()})
 
 
 class Types:
@@ -108,10 +108,10 @@ registry = {
     "ObjectWithProperty": ObjectWithProperty(),
     "ObjectWithPrivateMethod": ObjectWithPrivateMethod(),
     "ObjectWithContainerProperties": ObjectWithContainerProperties(),
-    "ObjectList": TuberContainer([ObjectWithContainerProperties(), ObjectWithContainerProperties()]),
-    "ObjectDict": TuberContainer({"a": ObjectWithContainerProperties(), "b": ObjectWithContainerProperties()}),
-    "ObjectListList": TuberContainer(
-        [TuberContainer([ObjectWithContainerProperties()]), TuberContainer([ObjectWithContainerProperties])]
+    "ObjectList": TuberArray([ObjectWithContainerProperties(), ObjectWithContainerProperties()]),
+    "ObjectDict": TuberArray({"a": ObjectWithContainerProperties(), "b": ObjectWithContainerProperties()}),
+    "ObjectListList": TuberArray(
+        [TuberArray([ObjectWithContainerProperties()]), TuberArray([ObjectWithContainerProperties])]
     ),
     "Container": TuberContainer({"a": ObjectWithProperty(), "b": ObjectWithMethod()}),
     "Types": Types(),
@@ -142,9 +142,7 @@ def Failed(warnings=None, **kwargs):
     return dict(error=kwargs)
 
 
-container_success = Succeeded(
-    __doc__=TuberContainer.__doc__.strip(), methods=["tuber_call", "tuber_meta"], properties=[]
-)
+container_success = Succeeded(__doc__=TuberArray.__doc__.strip(), methods=["tuber_call", "tuber_meta"], properties=[])
 
 
 def test_empty_request_array(tuber_call):

--- a/tests/test.py
+++ b/tests/test.py
@@ -853,3 +853,25 @@ async def test_tuberpy_container_context(tuber_call, accept_types, simple):
             r1 = await ctx()
 
     assert all([x == "expected return value" for x in r1])
+
+
+@pytest.mark.parametrize("simple", [True, False])
+@pytest.mark.parametrize("accept_types", ACCEPT_TYPES)
+@pytest.mark.asyncio
+async def test_tuberpy_container_properties(tuber_call, accept_types, simple):
+    """Collect properties and method calls for container objects"""
+    s = await resolve(accept_types=accept_types, simple=simple)
+
+    pobjs = s.ObjectWithContainerProperties.property_objects
+    r1 = pobjs.tuber_get("PROPERTY")
+    assert len(r1) == len(pobjs)
+    assert all([x == "expected property value" for x in r1])
+
+    mobjs = s.ObjectWithContainerProperties.method_objects
+    r2 = mobjs.tuber_call("method")
+    if not simple:
+        r2 = await r2
+
+    assert len(r2) == len(mobjs)
+    assert list(r2.keys()) == list(mobjs.keys())
+    assert all([x == "expected return value" for x in r2.values()])

--- a/tests/test.py
+++ b/tests/test.py
@@ -113,6 +113,7 @@ registry = {
     "ObjectListList": TuberContainer(
         [TuberContainer([ObjectWithContainerProperties()]), TuberContainer([ObjectWithContainerProperties])]
     ),
+    "Container": TuberContainer({"a": ObjectWithProperty(), "b": ObjectWithMethod()}),
     "Types": Types(),
     "NumPy": NumPy(),
     "Warnings": WarningsClass(),
@@ -670,13 +671,15 @@ async def test_tuberpy_containers(resolve):
     assert len(s.ObjectWithContainerProperties.property_objects) == 2
     assert list(s.ObjectWithContainerProperties.method_objects.keys()) == ["a", "b"]
     assert s.ObjectWithContainerProperties.property_objects[0].PROPERTY == "expected property value"
+    assert s.Container["a"].PROPERTY == "expected property value"
 
     r1 = await tuber_result(s.ObjectList[0].method_objects["a"].method())
     r2 = await tuber_result(s.ObjectListList[1][0].method_objects["a"].method())
     r3 = await tuber_result(s.ObjectDict["a"].method_objects["a"].method())
     r4 = await tuber_result(s.ObjectWithContainerProperties.method_objects["b"].method())
+    r5 = await tuber_result(s.Container["b"].method())
 
-    assert all([x == "expected return value" for x in [r1, r2, r3, r4]])
+    assert all([x == "expected return value" for x in [r1, r2, r3, r4, r5]])
 
 
 @pytest.mark.asyncio

--- a/tuber/client.py
+++ b/tuber/client.py
@@ -598,16 +598,24 @@ class SimpleTuberObject:
 
         # container of objects
         if hasattr(meta, "values"):
+            values = meta.values
             keys = getattr(meta, "keys", None)
-            if keys is None:
+            if keys is None or isinstance(keys, int):
                 islist = True
-                keys = range(len(meta.values))
-                items = [None] * len(meta.values)
+                if isinstance(keys, int):
+                    size = keys
+                    values = [values] * size
+                else:
+                    size = len(values)
+                keys = range(size)
+                items = [None] * size
             else:
                 islist = False
+                if not isinstance(values, list):
+                    values = [values] * len(keys)
                 items = dict()
 
-            for k, objmeta in zip(keys, meta.values):
+            for k, objmeta in zip(keys, values):
                 items[k] = self._resolve_object(item=k, meta=objmeta)
 
             self._items = items

--- a/tuber/client.py
+++ b/tuber/client.py
@@ -487,9 +487,6 @@ class SimpleTuberObject:
         if not self.is_container:
             raise TypeError(f"'{self._tuber_objname}' object is not a container")
 
-        if name in self._item_methods:
-            raise AttributeError("Use tuber_call for method attributes")
-
         if keys is None:
             if isinstance(self._items, list):
                 keys = range(len(self._items))
@@ -600,25 +597,19 @@ class SimpleTuberObject:
             setattr(self, propname, getattr(meta.properties, propname))
 
         # container of objects
-        if hasattr(meta, "container"):
-            cmeta = meta.container
-
-            keys = getattr(cmeta, "keys", None)
+        if hasattr(meta, "values"):
+            keys = getattr(meta, "keys", None)
             if keys is None:
                 islist = True
-                keys = range(len(cmeta.values))
-                items = [None] * len(cmeta.values)
+                keys = range(len(meta.values))
+                items = [None] * len(meta.values)
             else:
                 islist = False
                 items = dict()
 
-            for k, objmeta in zip(keys, cmeta.values):
-                objmeta.__doc__ = cmeta.item_doc
-                objmeta.methods = cmeta.item_methods
-                obj = self._resolve_object(item=k, meta=objmeta)
-                items[k] = obj
+            for k, objmeta in zip(keys, meta.values):
+                items[k] = self._resolve_object(item=k, meta=objmeta)
 
-            self._item_methods = cmeta.item_methods
             self._items = items
 
             if not islist:

--- a/tuber/schema.py
+++ b/tuber/schema.py
@@ -28,6 +28,7 @@ request_single = {
         },
         "property": {"type": "string"},
         "method": {"type": "string"},
+        "resolve": {"type": "boolean"},
     },
     "additionalProperties": False,
 }

--- a/tuber/schema.py
+++ b/tuber/schema.py
@@ -54,16 +54,26 @@ response_warnings = {
     },
 }
 
-response_metadata = {
+metadata_old = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "array",
+}
+
+metadata_recursive = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
-    "properties": {
-        "result": {
-            # any JSON type allowed
+    "additionalProperties": {
+        "type": "object",
+        "properties": {
+            "__doc__": {"type": ["string", "null"]},
+            "objects": {"type": "object"},
+            "properties": {"type": "object"},
+            "methods": {"type": "object"},
+            "keys": {"type": "array"},
+            "values": {"type": "array"},
         },
+        "additionalProperties": False,
     },
-    "required": ["result"],
-    "additionalProperties": False,
 }
 
 response_valid_single = {

--- a/tuber/schema.py
+++ b/tuber/schema.py
@@ -1,12 +1,11 @@
 """
 JSON Schemas for tuber requests and responses.
 
-These schemas are NOT verified in deployment - they are only used in test code,
-where a proxy server sits between the client-side tests and server and ensures
-conformance along the way.
-
-There is a sneaky side-effect - any tests that use this validation layer, by
-construction, do not test invalid requests.
+These schemas are only verified in deployment when the "--validate" flag is set
+on tuberd. This is not ordinarily true in deployment. Hence, jsonquery is a
+belt-and-braces way to ensure the server and client code are conformant to a
+particular specification. It is not meant to protect against ill-crafted or
+malicious requests.
 """
 
 """

--- a/tuber/schema.py
+++ b/tuber/schema.py
@@ -54,6 +54,18 @@ response_warnings = {
     },
 }
 
+response_metadata = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "result": {
+            # any JSON type allowed
+        },
+    },
+    "required": ["result"],
+    "additionalProperties": False,
+}
+
 response_valid_single = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",

--- a/tuber/schema.py
+++ b/tuber/schema.py
@@ -69,8 +69,18 @@ metadata_recursive = {
             "objects": {"type": "object"},
             "properties": {"type": "object"},
             "methods": {"type": "object"},
-            "keys": {"type": "array"},
-            "values": {"type": "array"},
+            "keys": {
+                "oneOf": [
+                    {"type": "array"},
+                    {"type": "integer"},
+                ],
+            },
+            "values": {
+                "oneOf": [
+                    {"type": "array"},
+                    {"type": "object"},
+                ],
+            },
         },
         "additionalProperties": False,
     },

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 import inspect
 import warnings
 import functools

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -438,9 +438,7 @@ class RequestHandler:
 
         try:
             if not ("object" in request and "method" in request):
-                description = self.describe(request)
-                self.validate(description, schema.response_metadata)
-                return description
+                return self.describe(request)
 
             objname = request["object"]
             obj = self.registry[objname]
@@ -498,8 +496,11 @@ class RequestHandler:
             # registry metadata
             if resolve:
                 objects = {obj: resolve_object(self.registry[obj]) for obj in self.registry}
+                self.validate(objects, schema.metadata_recursive)
             else:
                 objects = list(self.registry)
+                self.validate(objects, schema.metadata_old)
+
             return result_response(objects=objects)
 
         obj = self.registry[objname]

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -7,7 +7,7 @@ import warnings
 import functools
 from .codecs import Codecs
 
-__all__ = ["TuberContainer", "run"]
+__all__ = ["TuberRegistry", "TuberContainer", "run"]
 
 
 # request handling
@@ -396,8 +396,9 @@ class RequestHandler:
         """
         Arguments
         ---------
-        registry : dict
-            Dictionary of user-defined objects with properties and methods.
+        registry : dict or TuberRegistry instance
+            Dictionary of user-defined objects with properties and methods,
+            or a user-created TuberRegistry object.
         json_module : str
             Python package to use for encoding and decoding JSON requests.
         default_format : str
@@ -406,8 +407,10 @@ class RequestHandler:
             If True, validate incoming and outgoing packets with jsonschema.
         """
         # ensure registry is a dictionary
-        assert isinstance(registry, dict), "Invalid registry"
-        self.registry = TuberRegistry(registry)
+        assert isinstance(registry, (dict, TuberRegistry)), "Invalid registry"
+        if not isinstance(registry, TuberRegistry):
+            registry = TuberRegistry(registry)
+        self.registry = registry
 
         # populate codecs
         self.codecs = {}

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -181,7 +181,6 @@ class TuberContainer:
         return self.__data[item]
 
 
-
 class TuberRegistry:
     """
     Registry class.

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -209,17 +209,32 @@ class TuberRegistry(TuberResult):
     def __getitem__(self, objname):
         """
         Extract an object from the registry for the given name.  The object name
-        may be a simple string name for the registry entry, or an attribute
-        accessor.  For example, the name
+        may be a simple string name for the registry entry, or a list path
+        specifying the attributes and/or items to access.  For example, the path
 
-            "Class.Attribute[0]"
+            ["Class", ("Attribute", 0)]
 
         results in the object
 
             registry["Class"].Attribute[0]
         """
         try:
-            return eval(f"self.{objname}")
+            # simple object
+            if isinstance(objname, str):
+                return getattr(self, objname)
+
+            # object traversal
+            obj = self
+            for attr in objname:
+                if isinstance(attr, str):
+                    obj = getattr(obj, attr)
+                else:
+                    attr, items = attr[0], attr[1:]
+                    obj = getattr(obj, attr)
+                    for item in items:
+                        obj = obj[item]
+            return obj
+
         except Exception as e:
             raise e.__class__(f"{str(e)} (Invalid object name '{objname}')")
 

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -1,7 +1,7 @@
 import inspect
 import warnings
 import functools
-from .codecs import Codecs, TuberResult
+from .codecs import Codecs
 
 __all__ = ["TuberContainer", "run"]
 

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -5,7 +5,9 @@ import inspect
 import os
 import warnings
 import functools
+
 from .codecs import Codecs
+from . import schema
 
 __all__ = ["TuberRegistry", "TuberContainer", "run"]
 
@@ -412,11 +414,10 @@ class RequestHandler:
             return
 
         import jsonschema
-        from . import schema
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            jsonschema.validate(data, getattr(schema, schema_type))
+            jsonschema.validate(data, schema_type)
 
     def encode(self, data, fmt=None):
         """
@@ -427,7 +428,7 @@ class RequestHandler:
         if fmt is None:
             fmt = self.default_format
         try:
-            self.validate(data, "response")
+            self.validate(data, schema.response)
         except Exception as e:
             data = error_response(e)
         return fmt, self.codecs[fmt].encode(data)
@@ -441,7 +442,7 @@ class RequestHandler:
         if fmt is None:
             fmt = self.default_format
         data = self.codecs[fmt].decode(data)
-        self.validate(data, "request")
+        self.validate(data, schema.request)
         return data
 
     def handle(self, request, headers):

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -1,5 +1,6 @@
 import inspect
 import warnings
+import functools
 from .codecs import Codecs, TuberResult
 
 __all__ = ["TuberContainer", "run"]
@@ -201,6 +202,10 @@ class TuberContainer:
         return self.__data[item]
 
 
+def agetter(obj, attr, *items):
+    return functools.reduce(lambda o, i: o[i], items, getattr(obj, attr))
+
+
 class TuberRegistry(TuberResult):
     """
     Registry class.
@@ -224,16 +229,8 @@ class TuberRegistry(TuberResult):
                 return getattr(self, objname)
 
             # object traversal
-            obj = self
-            for attr in objname:
-                if isinstance(attr, str):
-                    obj = getattr(obj, attr)
-                else:
-                    attr, items = attr[0], attr[1:]
-                    obj = getattr(obj, attr)
-                    for item in items:
-                        obj = obj[item]
-            return obj
+            objname = [[x] if isinstance(x, str) else x for x in objname]
+            return functools.reduce(lambda obj, x: agetter(obj, *x), objname, self)
 
         except Exception as e:
             raise e.__class__(f"{str(e)} (Invalid object name '{objname}')")

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -181,9 +181,6 @@ class TuberContainer:
         return self.__data[item]
 
 
-def agetter(obj, attr, *items):
-    return functools.reduce(lambda o, i: o[i], items, getattr(obj, attr))
-
 
 class TuberRegistry:
     """
@@ -250,6 +247,10 @@ class TuberRegistry:
 
             # object traversal
             objname = [[x] if isinstance(x, str) else x for x in objname]
+
+            def agetter(obj, attr, *items):
+                return functools.reduce(lambda o, i: o[i], items, getattr(obj, attr))
+
             return functools.reduce(lambda obj, x: agetter(obj, *x), objname, self)
 
         except Exception as e:

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 
 import inspect
+import os
 import warnings
 import functools
 from .codecs import Codecs
@@ -577,7 +578,6 @@ def main():
     """
 
     import argparse as ap
-    import os
 
     P = ap.ArgumentParser(description="Tuber server")
     P.add_argument(


### PR DESCRIPTION
This PR extends the tuber API to enable dynamic attributes of TuberObjects.

Registry objects on the server may have attributes that are themselves registry objects.  To mark an attribute as such on the server, add the `__tuber_object__` attribute set to `True`.  Registry objects may also add metadata to the description returned from the server by providing a `tuber_meta()` method that returns a dictionary.

One implementation of such a registry object is the `TuberContainer` class -- this implements an interface for lists or dicts of registry objects. Importantly, all of the objects in a container must have the same set of attributes.  To create a container object on the server, wrap your list or dict object in a `TuberContainer` constructor.  Containers may also be attributes of other registry objects, so nested containers (e.g. lists of dicts) are possible.

Once a `TuberObject` is resolved on the client side, its attributes will mimic those of the corresponding registry object on the server side.  Dynamic attributes on the client object behave as `TuberObjects`, with access to method calls, properties, and contexts as usual.

Container attributes can also be iterated and indexed with a limited list-like or dict-like interface.  Additionally, container objects can perform operations on all contained items.  For example, to get the value of the same property attribute for all items in a container:

```
>>> obj.container.tuber_get("property")
[1, 2, 3]
```
Or to evaluate the same method with the same arguments for all items:
```
>>> await obj.container.tuber_call("method", arg1, arg2="test")
[1, 2, 3]
```

Context objects associated with a `TuberObject` can also have attributes and behave as containers, but delegate object resolution to the server. Importantly, a context object for a container does not know its dimensions or keys, so cannot be iterated directly.

The resolve interface has been overhauled into a single metadata request per object, with child attributes populated recursively.  The classic resolve interface remains in place on the server for backward compatibility.

See the test suite for examples of the extended API in action.