### PR TITLE
Create asyncio Future within running event loop

### DIFF
--- a/tuber/client.py
+++ b/tuber/client.py
@@ -292,7 +292,8 @@ class Context(SimpleContext):
         raise NotImplementedError
 
     def _add_call(self, **request):
-        future = asyncio.Future()
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
         self.calls.append((request, future))
         return future
 


### PR DESCRIPTION
This explicitly avoids a deprecation warning in Python 3.10+, where Futures cannot be created outside of a running event loop.