### PR TITLE
Bring serial API in line with async using requests-futures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ numpy
 orjson
 pytest
 requests
+requests-futures
 aiohttp
 pytest-asyncio
 cbor2

--- a/tests/test.py
+++ b/tests/test.py
@@ -465,9 +465,9 @@ async def test_tuberpy_async_context(tuber_call, accept_types, simple):
 
     if simple:
         with s.tuber_context() as ctx:
-            ctx.increment([1, 2, 3])
-            ctx.increment([2, 3, 4])
-            r1, r2 = ctx()
+            r1 = ctx.increment([1, 2, 3])
+            r2 = ctx.increment([2, 3, 4])
+        r1, r2 = [x.result() for x in [r1, r2]]
     else:
         async with s.tuber_context() as ctx:
             r1 = ctx.increment([1, 2, 3])
@@ -488,9 +488,10 @@ async def test_tuberpy_async_context_with_kwargs(tuber_call, accept_types, simpl
 
     if simple:
         with s.tuber_context(x=[1, 2, 3]) as ctx:
-            ctx.increment()
-            ctx.increment()
-            r1, r2 = ctx()
+            r1 = ctx.increment()
+            r2 = ctx.increment()
+
+        r1, r2 = [x.result() for x in [r1, r2]]
     else:
         async with s.tuber_context(x=[1, 2, 3]) as ctx:
             r1 = ctx.increment()
@@ -512,9 +513,9 @@ async def test_tuberpy_async_context_with_exception(tuber_call, accept_types, si
     with pytest.raises(tuber.TuberRemoteError):
         if simple:
             with s.tuber_context() as ctx:
-                ctx.increment([1, 2, 3])
-                ctx.increment(4)
-                ctx.increment([5, 6, 6])
+                r1 = ctx.increment([1, 2, 3])
+                r2 = ctx.increment(4)
+                r3 = ctx.increment([5, 6, 6])
         else:
             async with s.tuber_context() as ctx:
                 r1 = ctx.increment([1, 2, 3])  # fine
@@ -523,20 +524,26 @@ async def test_tuberpy_async_context_with_exception(tuber_call, accept_types, si
 
         # execution happens when ctx falls out of scope - exception raised
 
-    if simple:
-        return
-
     # the first call should have succeeded
-    await r1
+    if simple:
+        r1.result()
+    else:
+        await r1
 
     # the second call generated the exception
     with pytest.raises(tuber.TuberRemoteError):
-        await r2
+        if simple:
+            r2.result()
+        else:
+            await r2
 
     # the third call should not have been executed (propagated here as an
     # exception too)
     with pytest.raises(tuber.TuberRemoteError):
-        await r3
+        if simple:
+            r3.result()
+        else:
+            await r3
 
 
 @pytest.mark.parametrize("simple", [True, False])
@@ -584,23 +591,31 @@ async def test_tuberpy_async_context_with_unserializable(tuber_call, accept_type
 
     if simple:
         with s.tuber_context() as ctx:
-            ctx.increment([1, 2, 3])  # fine
-            ctx.unserializable()
-            ctx.increment([5, 6, 6])  # shouldn't execute
-        return
+            r1 = ctx.increment([1, 2, 3])  # fine
+            r2 = ctx.unserializable()
+            r3 = ctx.increment([5, 6, 6])  # shouldn't execute
 
     async with s.tuber_context() as ctx:
         r1 = ctx.increment([1, 2, 3])  # fine
         r2 = ctx.unserializable()
         r3 = ctx.increment([5, 6, 6])  # shouldn't execute
 
-    await r1
+    if simple:
+        r1.result()
+    else:
+        await r1
 
     with pytest.raises(tuber.TuberRemoteError):
-        await r2
+        if simple:
+            r2.result()
+        else:
+            await r2
 
     with pytest.raises(tuber.TuberRemoteError):
-        await r3
+        if simple:
+            r3.result()
+        else:
+            await r3
 
 
 @pytest.mark.parametrize("simple", [True, False])
@@ -706,14 +721,23 @@ async def test_tuberpy_continue_errors(tuber_call, accept_types, simple, continu
     with pytest.warns(match="This is a warning"):
         if simple:
             with s.tuber_context() as ctx:
-                ctx.Wrapper.increment([1, 2, 3])  # fine
-                ctx.Warnings.single_warning("This is a warning", error=True)
-                ctx.Wrapper.increment([5, 6, 6])  # should still execute
+                r1 = ctx.Wrapper.increment([1, 2, 3])  # fine
+                r2 = ctx.Warnings.single_warning("This is a warning", error=True)
+                r3 = ctx.Wrapper.increment([5, 6, 6])  # should still execute
                 if not continue_on_error:
                     with pytest.raises(tuber.TuberRemoteError):
                         ctx()
+                    with pytest.raises(tuber.TuberRemoteError):
+                        r3.result()
                 else:
-                    r1, r2, r3 = ctx(continue_on_error=True)
+                    try:
+                        ctx(continue_on_error=True)
+                    except tuber.TuberRemoteError:
+                        pass
+                    with pytest.raises(tuber.TuberRemoteError):
+                        r2.result()
+                    r1 = r1.result()
+                    r3 = r3.result()
         else:
             async with s.tuber_context() as ctx:
                 r1 = ctx.Wrapper.increment([1, 2, 3])  # fine
@@ -738,6 +762,4 @@ async def test_tuberpy_continue_errors(tuber_call, accept_types, simple, continu
         return
 
     assert r1 == [2, 3, 4]
-    if simple:
-        assert isinstance(r2, tuber.TuberRemoteError)  # this is an error response returned as a result
     assert r3 == [6, 7, 7]

--- a/tuber/client.py
+++ b/tuber/client.py
@@ -4,6 +4,7 @@ Tuber object interface
 
 from __future__ import annotations
 import asyncio
+import concurrent
 import textwrap
 import types
 import warnings
@@ -142,7 +143,9 @@ class SimpleContext:
             self()
 
     def _add_call(self, **request):
-        self.calls.append(request)
+        future = concurrent.futures.Future()
+        self.calls.append((request, future))
+        return future
 
     def __getattr__(self, name):
         if attribute_blacklisted(name):
@@ -192,26 +195,46 @@ class SimpleContext:
 
         # An empty Context returns an empty list of calls
         if not self.calls:
-            return []
+            return
 
-        calls = list(self.calls)
-        self.calls.clear()
+        calls = []
+        futures = []
+        while self.calls:
+            (c, f) = self.calls.pop(0)
 
-        import requests
+            calls.append(c)
+            futures.append(f)
+
+        if not hasattr(self.obj, "_tuber_session"):
+            # session object should persist beyond the lifetime of the context,
+            # akin to the asyncio event loop
+            from requests_futures.sessions import FuturesSession
+
+            self.obj._tuber_session = FuturesSession()
+
+        cs = self.obj._tuber_session
 
         # Declare the media types we want to allow getting back
         headers = {"Accept": ", ".join(self.accept_types)}
         if continue_on_error:
             headers["X-Tuber-Options"] = "continue-on-error"
+
         # Create a HTTP request to complete the call.
-        return requests.post(self.uri, json=calls, headers=headers)
+        # Returns a Future whose result has been processed by the response hook.
+        return cs.post(self.uri, json=calls, headers=headers, hooks={"response": self._response_hook(futures)})
 
-    def receive(self, response: "requests.Response", continue_on_error: bool = False):
+    def _response_hook(self, futures: list["concurrent.futures.Future"]):
+        """Hook function for parsing a response from the server into a list of futures for each context call"""
+
+        def hook(r, *args, **kwargs):
+            results = self._receive(r, futures)
+            r.tuber_results = results
+            return r
+
+        return hook
+
+    def _receive(self, response: "requests.Response", futures: list["concurrent.futures.Future"]):
         """Parse response from a previously sent HTTP request."""
-
-        # An empty Context returns an empty list of calls
-        if response is None or response == []:
-            return []
 
         with response as resp:
             raw_out = resp.content
@@ -236,8 +259,7 @@ class SimpleContext:
             # best we can.
             raise TuberRemoteError(json_out.error.message)
 
-        results = []
-        for r in json_out:
+        for f, r in zip(futures, json_out):
             # Always emit warnings, if any occurred
             if hasattr(r, "warnings") and r.warnings:
                 for w in r.warnings:
@@ -245,24 +267,29 @@ class SimpleContext:
 
             # Resolve either a result or an error
             if hasattr(r, "error") and r.error:
-                exc = TuberRemoteError(getattr(r.error, "message", "Unknown error"))
-                if continue_on_error:
-                    results.append(exc)
+                if hasattr(r.error, "message"):
+                    f.set_exception(TuberRemoteError(r.error.message))
                 else:
-                    raise exc
-            elif hasattr(r, "result"):
-                results.append(r.result)
+                    f.set_exception(TuberRemoteError("Unknown error"))
             else:
-                raise TuberError("Result has no 'result' attribute")
+                if hasattr(r, "result"):
+                    f.set_result(r.result)
+                else:
+                    f.set_exception(TuberError("Result has no 'result' attribute"))
 
         # Return a list of results
-        return results
+        return [f.result() for f in futures]
+
+    def receive(self, response: "concurrent.futures.Future"):
+        """Wait for a response from a previously sent HTTP request."""
+        if response is None:
+            return []
+        return response.result().tuber_results
 
     def __call__(self, continue_on_error: bool = False):
-        """Break off a set of calls and return them for execution."""
-
+        """Wait for any pending calls to complete and return the results from the server"""
         resp = self.send(continue_on_error=continue_on_error)
-        return self.receive(resp, continue_on_error=continue_on_error)
+        return self.receive(resp)
 
 
 class Context(SimpleContext):
@@ -477,9 +504,8 @@ class SimpleTuberObject:
             def invoke_wrapper(name, props):
                 def invoke(self, *args, **kwargs):
                     with self.tuber_context() as ctx:
-                        getattr(ctx, name)(*args, **kwargs)
-                        results = ctx()
-                    return results[0]
+                        r = getattr(ctx, name)(*args, **kwargs)
+                    return r.result()
 
                 return tuber_wrapper(invoke, props)
 


### PR DESCRIPTION
This PR rearranges the `SimpleContext` object to use a `FuturesSession` for dispatching HTTP requests to a thread pool, rather than waiting for them to complete on the main thread.  This brings the API for the `SimpleContext` object in line with that of the async `Context` object.  `TuberObject` methods are executed serially without `await`, and context methods return a `Future` whose `result()` method returns the corresponding result from the server.  Calling a context directly blocks until it responds, akin to the `await ctx()` API of the async `Context`.

To allow for asynchronous communication with several servers, the (non-blocking) `SimpleContext.send()` method returns a `Future` object whose (blocking) `result()` method contains the full `requests.Response` object as processed from the server.  The `SimpleContext.receive()` method can then be used to block and return the results of each method executed on the server.