### PR TITLE
Remove dependency on fmt

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install C++ dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libmicrohttpd-dev libfmt-dev pybind11-dev
+        sudo apt-get install -y libmicrohttpd-dev pybind11-dev
 
     - name: Build and install libhttpserver
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ find_package(Threads REQUIRED)
 include(CTest)
 
 pybind11_add_module(_tuber_runtime MODULE src/server.cpp)
+target_include_directories(_tuber_runtime PUBLIC ${LIBHTTPSERVER_INCLUDE_DIRS})
 target_link_libraries(_tuber_runtime PUBLIC ${LIBHTTPSERVER_LIBRARIES} Threads::Threads)
 
 pybind11_add_module(test_module MODULE tests/test_module.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ if(EXISTS ${CMAKE_SOURCE_DIR}/deps)
 endif()
 
 find_package(Python COMPONENTS Interpreter Development.Module REQUIRED)
-find_package(fmt REQUIRED)
 find_package(LibHttpServer REQUIRED)
 find_package(pybind11 REQUIRED)
 find_package(Threads REQUIRED)
@@ -36,7 +35,7 @@ find_package(Threads REQUIRED)
 include(CTest)
 
 pybind11_add_module(_tuber_runtime MODULE src/server.cpp)
-target_link_libraries(_tuber_runtime PUBLIC fmt::fmt ${LIBHTTPSERVER_LIBRARIES} Threads::Threads)
+target_link_libraries(_tuber_runtime PUBLIC ${LIBHTTPSERVER_LIBRARIES} Threads::Threads)
 
 pybind11_add_module(test_module MODULE tests/test_module.cpp)
 target_include_directories(test_module PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/README.rst
+++ b/README.rst
@@ -139,8 +139,8 @@ CPython 3.8+:
 
    pip install tuberd
 
-Building from source requires the ``libfmt`` and ``libmicrohttpd`` dependencies,
-along with ``libhttpserver``.  To simplify the build process, the
+Building from source requires the ``libmicrohttpd`` and ``libhttpserver``
+dependencies.  To simplify the build process, the
 ``wheels/install_deps.sh`` script can be used to build all the dependencies
 locally and compile against them.  In this instance, ``cmake`` should be able to
 discover the appropriate paths for all dependencies.  Use the ``BUILD_DEPS``

--- a/wheels/install_deps.sh
+++ b/wheels/install_deps.sh
@@ -28,15 +28,6 @@ cd $scriptdir/..
 prefix=$PWD/deps
 cd $prefix
 
-[ -e fmt-10.2.1.zip ] || FETCH https://github.com/fmtlib/fmt/releases/download/10.2.1/fmt-10.2.1.zip
-[ -e fmt-10.2.1 ] || unzip fmt-10.2.1.zip
-[ -e fmt-10.2.1/build ] || mkdir fmt-10.2.1/build
-cd fmt-10.2.1/build
-cmake .. -DCMAKE_INSTALL_PREFIX=$prefix -DFMT_TEST=FALSE -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE
-make
-make install
-cd $prefix
-
 [ -e libmicrohttpd-1.0.1.tar.gz ] || FETCH https://github.com/Karlson2k/libmicrohttpd/releases/download/v1.0.1/libmicrohttpd-1.0.1.tar.gz
 [ -e libmicrohttpd-1.0.1 ] || tar xzf libmicrohttpd-1.0.1.tar.gz
 cd libmicrohttpd-1.0.1


### PR DESCRIPTION
`fmt` isn't adding much value, and can be mildly annoying, e.g. by default it builds only a static library but tuber now doesn't like linking with that. It's simpler to just stop using it. 