### PR TITLE
Some minor fixes for TuberContainer objects

### DIFF
--- a/tuber/client.py
+++ b/tuber/client.py
@@ -477,25 +477,6 @@ class SimpleTuberObject:
         # Useful hint
         raise AttributeError(f"'{self._tuber_objname}' has no attribute '{name}'.  Did you run tuber_resolve()?")
 
-    def tuber_get(self, name: str, keys: list[str | int] | None = None):
-        """Get a property of every container item.
-
-        If object is a container, return a list of property values for each
-        item.  If `keys` is supplied, return only the values corresponding to
-        the given set of container items.
-        """
-        if not self.is_container:
-            raise TypeError(f"'{self._tuber_objname}' object is not a container")
-
-        if keys is None:
-            if isinstance(self._items, list):
-                keys = range(len(self._items))
-            else:
-                keys = self._items.keys()
-        items = [self._items[k] for k in keys]
-
-        return [getattr(v, name) for v in self._items]
-
     def __len__(self):
         try:
             return len(self._items)
@@ -624,6 +605,22 @@ class SimpleTuberObject:
                 setattr(self, "keys", types.MethodType(lambda o: o._items.keys(), self))
                 setattr(self, "values", types.MethodType(lambda o: o._items.values(), self))
                 setattr(self, "items", types.MethodType(lambda o: o._items.items(), self))
+
+            def tuber_get(self, name: str, keys: list[str | int] | None = None):
+                """Get a property of every container item.
+
+                Return a list of property values for each item.  If ``keys`` is
+                supplied, return only the values corresponding to the given set
+                of container items.
+                """
+                if keys is None:
+                    if isinstance(self._items, list):
+                        keys = range(len(self._items))
+                    else:
+                        keys = self._items.keys()
+                return [getattr(self._items[k], name) for k in keys]
+
+            setattr(self, "tuber_get", types.MethodType(tuber_get, self))
 
         self._tuber_meta = meta
         return meta

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -194,6 +194,19 @@ class TuberContainer:
 class TuberArray(TuberContainer):
     """Container for grouping identical objects"""
 
+    def __init__(self, items):
+        super().__init__(items)
+
+        if isinstance(self._items, list):
+            values = self._items
+        else:
+            values = list(self._items.values())
+
+        tp = type(values[0])
+        for v in values:
+            if not isinstance(v, tp):
+                raise TypeError("Array items must have the same type")
+
     def tuber_meta(self):
         """
         Return a dict with descriptions of all items in the collection, with


### PR DESCRIPTION
* Ensure that array elements all have the same type.
* Assign tuber_get method attribute only to container objects.