### PR TITLE
Strip __signature__ from server and client side metadata

### DIFF
--- a/include/tuber_support.hpp
+++ b/include/tuber_support.hpp
@@ -146,6 +146,20 @@ namespace PYBIND11_NAMESPACE {
 			object type = unique(ctor(**kwargs));
 			setattr(scope, name, type);
 			detail::type_caster<T>::bind(type, cpp_entries);
+
+			/* Add a custom __repr__ method that shows a string interpretation */
+			pybind11::setattr(type, "__repr__", pybind11::cpp_function(
+				[type](pybind11::object self) -> std::string {
+					T value = self.cast<T>();
+
+					for (const auto& item : type.attr("__members__").cast<pybind11::dict>())
+						if (item.second.cast<T>() == value)
+							return '"' + item.first.cast<std::string>() + '"';
+
+					return "UNKNOWN";
+				},
+				pybind11::is_method(type)
+			));
 		}
 
 		str_enum& value(const char* name, T value) & {

--- a/tests/test.py
+++ b/tests/test.py
@@ -435,11 +435,7 @@ async def test_tuberpy_method_docstrings(resolve):
     """Ensure docstrings in C++ methods end up in the TuberObject's __doc__ dunder."""
 
     s = await resolve("Wrapper")
-    assert s.increment.__doc__.strip() == tm.Wrapper.increment.__doc__.split("\n", 1)[-1].strip()
-
-    # check signature
-    sig = inspect.signature(s.increment)
-    assert "x" in sig.parameters
+    assert s.increment.__doc__.strip() == tm.Wrapper.increment.__doc__.strip()
 
 
 @pytest.mark.asyncio
@@ -531,7 +527,6 @@ async def test_tuberpy_serialize_enum_class(resolve):
 
     # Ensure we can round-trip it back into C++
     r = await tuber_result(s.is_x(r))
-
     assert r is True
 
 

--- a/tests/test_module.cpp
+++ b/tests/test_module.cpp
@@ -26,16 +26,20 @@ class Wrapper {
 
 PYBIND11_MODULE(test_module, m) {
 
-	py::str_enum<Kind> kind(m, "Kind");
-	kind.value("X", Kind::X)
-		.value("Y", Kind::Y);
+	/* this forced scope ensures Kind is registered before it's used in
+	 * default arguments below. */
+	{
+		py::str_enum<Kind> kind(m, "Kind");
+		kind.value("X", Kind::X)
+			.value("Y", Kind::Y);
+	}
 
 	auto w = py::class_<Wrapper>(m, "Wrapper")
 		.def(py::init())
 		.def("return_x", &Wrapper::return_x)
 		.def("return_y", &Wrapper::return_y)
-		.def("is_x", &Wrapper::is_x)
-		.def("is_y", &Wrapper::is_y)
+		.def("is_x", &Wrapper::is_x, "k"_a=Kind::X)
+		.def("is_y", &Wrapper::is_y, "k"_a=Kind::Y)
 		.def("increment", &Wrapper::increment,
 				"x"_a,
 				"A function that increments each element in its argument list.")

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -36,21 +36,7 @@ def resolve_method(method):
     Return a description of a method.
     """
     doc = inspect.getdoc(method)
-    sig = None
-    try:
-        sig = str(inspect.signature(method))
-    except:
-        # pybind docstrings include a signature as the first line
-        if doc and doc.startswith(method.__name__ + "("):
-            if "\n" in doc:
-                sig, doc = doc.split("\n", 1)
-                doc = doc.strip()
-            else:
-                sig = doc
-                doc = None
-            sig = "(" + sig.split("(", 1)[1]
-
-    return dict(__doc__=doc, __signature__=sig)
+    return dict(__doc__=doc)
 
 
 def check_attribute(obj, d):
@@ -178,7 +164,6 @@ class TuberContainer:
         return out
 
     def __getattr__(self, name):
-        print("getattr", name)
         return getattr(self._items, name)
 
     def __len__(self):


### PR DESCRIPTION
For now, pybind11 is our primary binding vehicle, and it doesn't populate signatures in a way that we can export cleanly. They are just the first line of the DocString, and that's it. Maybe Nanobind does (or will do) a better job of metadata transport.

On the client side, parsing these signatures back into signature objects is hard to do without creating vulnerabilities. I think we would need to teach the server to export a JSONSchema-like thing rather than expecting the client side to parse a signature string. Inspect does not currently work with annotations in __signature__ or __text_signature__.

In both cases, we don't really _need_ signatures for anything and are relying on a big-ball-of-text __doc__  to transport DocStrings anyhow. May as well tuck signatures back into the top of this.

I would love to revisit this when the binding side (pybind11/nanobind) and the client side (inspect) firm up a little.