### PR TITLE
Server-side signature metadata

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -435,7 +435,11 @@ async def test_tuberpy_method_docstrings(resolve):
     """Ensure docstrings in C++ methods end up in the TuberObject's __doc__ dunder."""
 
     s = await resolve("Wrapper")
-    assert s.increment.__doc__.strip() == tm.Wrapper.increment.__doc__.strip()
+    assert s.increment.__doc__.strip() == tm.Wrapper.increment.__doc__.split("\n", 1)[-1].strip()
+
+    # check signature
+    sig = inspect.signature(s.increment)
+    assert "x" in sig.parameters
 
 
 @pytest.mark.asyncio

--- a/tuber/client.py
+++ b/tuber/client.py
@@ -75,10 +75,13 @@ def tuber_wrapper(func: callable, meta: TuberResult):
 
     # Attach a function signature, if provided and valid
     try:
-        func.__signature__ = inspect.Signature(
-            [inspect.Parameter(**vars(par)) for par in meta.parameters],
-            return_annotation=getattr(meta, "return_annotation", inspect.Signature.empty),
-        )
+        if isinstance(meta.__signature__, str):
+            func.__text_signature__ = meta.__signature__
+        else:
+            sig = meta.__signature__
+            if not isinstance(sig.parameters[0], inspect.Parameter):
+                sig.parameters = [inspect.Parameter(**vars(p)) for p in sig.parameters]
+            func.__signature__ = inspect.Signature(**vars(sig))
     except:
         pass
 

--- a/tuber/client.py
+++ b/tuber/client.py
@@ -74,25 +74,11 @@ def tuber_wrapper(func: callable, meta: TuberResult):
         pass
 
     # Attach a function signature, if provided and valid
-    empty = inspect.Parameter.empty
-
-    def P(name, default=empty):
-        return inspect.Parameter(
-            name,
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            default=default,
-            annotation=getattr(meta.annotations, name, empty),
-        )
-
     try:
-        params = []
-        for arg in meta.args:
-            params.append(P(arg))
-        for k in meta.kwargs:
-            params.append(P(k, getattr(meta.kwargs, k)))
-        ret = getattr(meta.annotations, "return", empty)
-        sig = inspect.Signature(params, return_annotation=ret)
-        func.__signature__ = sig
+        func.__signature__ = inspect.Signature(
+            [inspect.Parameter(**vars(par)) for par in meta.parameters],
+            return_annotation=getattr(meta, "return_annotation", inspect.Signature.empty),
+        )
     except:
         pass
 

--- a/tuber/client.py
+++ b/tuber/client.py
@@ -461,6 +461,7 @@ class SimpleTuberObject:
     """
 
     _context_class = SimpleContext
+    _tuber_objname = None
 
     def __init__(
         self,

--- a/tuber/schema.py
+++ b/tuber/schema.py
@@ -52,15 +52,30 @@ metadata_method = {
     "title": "method metadata",
     "type": "object",
     "properties": {
-        "__doc__": {
-            "oneOf": [
-                {"type": "string"},
-                {"type": "null"},
-            ],
+        "__doc__": {"oneOf": [{"type": "string"}, {"type": "null"}]},
+        "__signature__": {
+            "type": "object",
+            "properties": {
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "annotation": {"type": "string"},
+                            "kind": {"type": "number"},
+                            "name": {"type": "string"},
+                            "default": {"type": ["string", "number", "object", "array", "boolean", "null"]},
+                        },
+                        "additionalProperties": False,
+                    },
+                },
+                "return_annotation": {"type": "string"},
+            },
+            "additionalProperties": False,
         },
         # argument descriptor goes here
     },
-    "additionalProperties": True,
+    "additionalProperties": False,
 }
 
 # Description of an object
@@ -102,10 +117,7 @@ metadata_root = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "root metadata",
     "type": "object",
-    "properties": {
-        "objects": metadata_object,
-        "additionalProperties": False,
-    },
+    "additionalProperties": metadata_object,
 }
 
 """

--- a/tuber/schema.py
+++ b/tuber/schema.py
@@ -44,6 +44,71 @@ request = {
 }
 
 """
+Metadata schema (resolved only)
+"""
+
+metadata_method = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "method metadata",
+    "type": "object",
+    "properties": {
+        "__doc__": {
+            "oneOf": [
+                {"type": "string"},
+                {"type": "null"},
+            ],
+        },
+        # argument descriptor goes here
+    },
+    "additionalProperties": True,
+}
+
+# Description of an object
+metadata_object = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "object metadata",
+    "type": "object",
+    "properties": {
+        "__doc__": {"type": ["string", "null"]},
+        "properties": {"type": "object"},
+        "methods": {
+            "type": "object",
+            "additionalProperties": metadata_method,
+        },
+        "keys": {
+            "oneOf": [
+                {"type": "array"},
+                {"type": "integer"},
+            ],
+        },
+        "values": {
+            "oneOf": [
+                {"type": "array"},
+                {"type": "object"},
+            ],
+        },
+        "objects": {
+            "oneOf": [
+                {"type": "object"},
+                {"type": "null"},
+            ],
+        },
+    },
+    "additionalProperties": False,
+}
+
+# Root metadata, when no object/method/property has been specified
+metadata_root = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "root metadata",
+    "type": "object",
+    "properties": {
+        "objects": metadata_object,
+        "additionalProperties": False,
+    },
+}
+
+"""
 Response schema
 """
 
@@ -51,38 +116,6 @@ response_warnings = {
     "type": "array",
     "items": {
         "type": "string",
-    },
-}
-
-metadata_old = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "type": "array",
-}
-
-metadata_recursive = {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "type": "object",
-    "additionalProperties": {
-        "type": "object",
-        "properties": {
-            "__doc__": {"type": ["string", "null"]},
-            "objects": {"type": "object"},
-            "properties": {"type": "object"},
-            "methods": {"type": "object"},
-            "keys": {
-                "oneOf": [
-                    {"type": "array"},
-                    {"type": "integer"},
-                ],
-            },
-            "values": {
-                "oneOf": [
-                    {"type": "array"},
-                    {"type": "object"},
-                ],
-            },
-        },
-        "additionalProperties": False,
     },
 }
 

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -74,9 +74,11 @@ def resolve_method(method):
             sig = None
 
     if sig is not None:
+        sout = {}
+
         # parse signature parameters
         if sig.return_annotation != sig.empty:
-            out["return_annotation"] = str(sig.return_annotation)
+            sout["return_annotation"] = str(sig.return_annotation)
 
         params = []
         for name, par in sig.parameters.items():
@@ -86,7 +88,8 @@ def resolve_method(method):
             if par.annotation != par.empty:
                 p["annotation"] = str(par.annotation)
             params.append(p)
-        out["parameters"] = params
+        sout["parameters"] = params
+        out["__signature__"] = sout
 
     return out
 

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -97,6 +97,9 @@ def check_attribute(obj, d):
     """
     if d.startswith("__"):
         return False
+    if d.startswith("_pybind11"):
+        # pybind11 internals - e.g. _pybind11_conduit_v1_
+        return False
     if d in getattr(obj, "__tuber_exclude__", []):
         return False
     for c in obj.__class__.mro():

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -579,10 +579,9 @@ class RequestHandler:
             # registry metadata
             if resolve:
                 objects = {obj: resolve_object(self.registry[obj]) for obj in self.registry}
-                self.validate(objects, schema.metadata_recursive)
+                self.validate(objects, schema.metadata_root)
             else:
                 objects = list(self.registry)
-                self.validate(objects, schema.metadata_old)
 
             return result_response(objects=objects)
 
@@ -590,7 +589,10 @@ class RequestHandler:
 
         if not methodname and not propertyname:
             # Object metadata.
-            return result_response(**resolve_object(obj, recursive=resolve))
+            obj_meta = resolve_object(obj, recursive=resolve)
+            if resolve:
+                self.validate(obj_meta, schema.metadata_object)
+            return result_response(**obj_meta)
 
         if propertyname:
             # Sanity check

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -75,23 +75,18 @@ def resolve_method(method):
 
     if sig is not None:
         # parse signature parameters
-        annotations = {}
         if sig.return_annotation != sig.empty:
-            annotations["return"] = str(sig.return_annotation)
+            out["return_annotation"] = str(sig.return_annotation)
 
-        args = []
-        kwargs = {}
+        params = []
         for name, par in sig.parameters.items():
-            if par.default == par.empty:
-                args.append(par.name)
-            else:
-                kwargs[par.name] = par.default
+            p = {"name": name, "kind": int(par.kind)}
+            if par.default != par.empty:
+                p["default"] = par.default
             if par.annotation != par.empty:
-                annotations[par.name] = str(par.annotation)
-
-        out["args"] = args
-        out["kwargs"] = kwargs
-        out["annotations"] = annotations
+                p["annotation"] = str(par.annotation)
+            params.append(p)
+        out["parameters"] = params
 
     return out
 


### PR DESCRIPTION
Extract argument names and default values from method signatures on the server, and use this metadata to reconstruct the method signature on the client.

This construction avoids spurious code execution on the client side, and thus builds all signatures with unevaluated string annotations.