### PR TITLE
Prevent mDNS resolver breakage via aiodns

### DIFF
--- a/tuber/client.py
+++ b/tuber/client.py
@@ -366,8 +366,13 @@ class Context(SimpleContext):
             # hide import for non-library package that may not be invoked
             import aiohttp
 
+            # AsyncResolver does not support mDNS
+            resolver = aiohttp.resolver.ThreadedResolver()
+
             # Monkey-patch tuber session memory handling with the running event loop
-            loop._tuber_session = aiohttp.ClientSession(json_serialize=Codecs["json"].encode)
+            loop._tuber_session = aiohttp.ClientSession(
+                json_serialize=Codecs["json"].encode, connector=aiohttp.TCPConnector(resolver=resolver)
+            )
 
             # Ensure that ClientSession.close() is called when the loop is
             # closed.  ClientSession.__del__ does not close the session, so it


### PR DESCRIPTION
aiodns is now the DefaultResolver when installed, and for some reason, this whole code path doesn't support mDNS resolution.