### PR TITLE
Don't warn about missing codec on server startup

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,8 +7,8 @@ on:
     branches: [ master ]
 
 env:
-  CC: gcc-10
-  CXX: g++-10
+  CC: gcc-14
+  CXX: g++-14
   LD_LIBRARY_PATH: /usr/local/lib # this is where libhttpserver installs itself
 
 jobs:

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -376,7 +376,7 @@ class RequestHandler:
         try:
             self.codecs["application/cbor"] = Codecs["cbor"]
         except Exception as e:
-            warnings.warn(f"Unable to import cbor codec ({str(e)})")
+            pass
 
         assert default_format in self.codecs, f"Missing codec for {default_format}"
         self.default_format = default_format


### PR DESCRIPTION
This warning adds confusion when the cbor codec is not in use.