### PR TITLE
Cancel all futures on serialization error

### DIFF
--- a/tuber/client.py
+++ b/tuber/client.py
@@ -279,6 +279,8 @@ class SimpleContext:
             # We made an array request, and received an object response
             # because of an exception-catching scope in the server. Do the
             # best we can.
+            for f in futures:
+                f.cancel()
             raise TuberRemoteError(json_out.error.message)
 
         for f, r in zip(futures, json_out):
@@ -419,6 +421,8 @@ class Context(SimpleContext):
             # We made an array request, and received an object response
             # because of an exception-catching scope in the server. Do the
             # best we can.
+            for f in futures:
+                f.cancel()
             raise TuberRemoteError(json_out.error.message)
 
         # Resolve futures


### PR DESCRIPTION
If an error is raised by the server while constructing the response message, then the response futures are not populated with either exceptions or results. Calling .result() on such futures may cause the code to hang indefinitely. Prevent this behavior by canceling the futures, so that any attempt to access a result will immediately raise an error.