### PR TITLE
Option to return dict instead of TuberResult from JSON decoder

### DIFF
--- a/tuber/client.py
+++ b/tuber/client.py
@@ -299,7 +299,7 @@ class SimpleContext:
 
         for f, r in zip(futures, json_out):
             # Always emit warnings, if any occurred
-            if hasattr(r, "warnings") and getkey(r, "warnings"):
+            if haskey(r, "warnings") and getkey(r, "warnings"):
                 for w in getkey(r, "warnings"):
                     warnings.warn(w)
 

--- a/tuber/client.py
+++ b/tuber/client.py
@@ -274,12 +274,16 @@ class SimpleContext:
         return_dicts: bool = False,
     ):
         if return_dicts:
+
             def haskey(d, k):
                 return isinstance(d, dict) and k in d
+
             def getkey(d, *k):
                 return functools.reduce(lambda d, k: d[k], k, d)
+
         else:
             haskey = hasattr
+
             def getkey(d, *k):
                 return functools.reduce(lambda d, k: getattr(d, k), k, d)
 
@@ -346,9 +350,7 @@ class SimpleContext:
             # this is slightly more liberal than checking that it is really among those we declared
             if content_type not in AcceptTypes:
                 raise TuberError(f"Unexpected response content type: {content_type}")
-            json_out = AcceptTypes[content_type](
-                raw_out, resp.apparent_encoding, return_dicts=return_dicts
-            )
+            json_out = AcceptTypes[content_type](raw_out, resp.apparent_encoding, return_dicts=return_dicts)
 
         return self._parse_json(json_out, futures, return_exceptions, return_dicts)
 

--- a/tuber/client.py
+++ b/tuber/client.py
@@ -828,7 +828,7 @@ class SimpleTuberObject:
         """Resolve a remote method call into a callable function"""
 
         def invoke(self, *args, **kwargs):
-            with self.tuber_context(convert_json=True, return_exceptions=False) as ctx:
+            with self.tuber_context() as ctx:
                 r = getattr(ctx, name)(*args, **kwargs)
             return r.result()
 
@@ -983,7 +983,7 @@ class TuberObject(SimpleTuberObject):
         """Resolve a remote method call into an async callable function"""
 
         async def invoke(self, *args, **kwargs):
-            async with self.tuber_context(convert_json=True, return_exceptions=False) as ctx:
+            async with self.tuber_context() as ctx:
                 getattr(ctx, name)(*args, **kwargs)
                 results = await ctx()
             return results[0]

--- a/tuber/client.py
+++ b/tuber/client.py
@@ -271,7 +271,7 @@ class SimpleContext:
             Any remaining keyword arguments are added as additional keywords to any
             method call made by this context.
         """
-        self.calls: list[tuple[dict, concurrent.futures.Future]] = []
+        self.calls: list[tuple[dict, "Future"]] = []
         self.obj = obj
         self.uri = f"http://{obj._tuber_host}/tuber"
         if accept_types is None:
@@ -568,27 +568,6 @@ class Context(SimpleContext):
     Commands are dispatched strictly in-order, but are automatically bundled
     up to reduce roundtrips.
     """
-
-    def __init__(self, obj: "TuberObject", **kwargs):
-        """
-        Arguments
-        ---------
-        obj : TuberObject
-            Parent tuber object whose methods to call.
-        accept_types : list of str
-            List of codecs that the client is able to decode.
-        convert_json : bool
-            If True (default), all responses from the server should be converted into
-            namespace objects by default.  This default may be overridden in the
-            context construction or in each individual context call.
-        return_exceptions : bool
-            If True, return server-side exceptions in the response list by default.
-            If False (default), raise the exception when parsing the server response.
-            This default may be overridden in the context construction or in each
-            individual context call.
-        """
-        super().__init__(obj, **kwargs)
-        self.calls: list[tuple[dict, asyncio.Future]] = []
 
     async def __aenter__(self):
         return self

--- a/tuber/client.py
+++ b/tuber/client.py
@@ -249,7 +249,7 @@ class SimpleContext:
         accept_types: list[str] | None = None,
         convert_json: bool | None = None,
         return_exceptions: bool | None = None,
-        **ctx_kwargs
+        **ctx_kwargs,
     ):
         """
         Arguments

--- a/tuber/codecs.py
+++ b/tuber/codecs.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence, Mapping
 from collections import namedtuple
 import sys
+import functools
 
 try:
     import numpy
@@ -42,6 +43,43 @@ class TuberResult:
     def __repr__(self):
         "Return a concise representation string"
         return repr(self.__dict__)
+
+    def __getitem__(self, objname):
+        """
+        Extract an item from this object for the given name.
+
+        The object may be a simple string name for an object attribute, or a list
+        path specifying the attributes and/or items to access.  For example, the
+        trivial object:
+
+            >>> class SomeObject: LIST = [1, 2, 3, 4]
+            >>> r = TuberResult(dict(cls=SomeObject()))
+
+        ...can be navigated as follows:
+
+            >>> r.cls.LIST[0]
+            1
+
+        ...equivalently
+
+            >>> r["cls", ("LIST", 0)]
+            1
+        """
+        try:
+            # simple object
+            if isinstance(objname, str):
+                return getattr(self, objname)
+
+            # object traversal
+            objname = [[x] if isinstance(x, str) else x for x in objname]
+
+            def agetter(obj, attr, *items):
+                return functools.reduce(lambda o, i: o[i], items, getattr(obj, attr))
+
+            return functools.reduce(lambda obj, x: agetter(obj, *x), objname, self)
+
+        except Exception as e:
+            raise e.__class__(f"{str(e)} (Invalid object name '{objname}')")
 
 
 def wrap_bytes_for_json(obj):

--- a/tuber/codecs.py
+++ b/tuber/codecs.py
@@ -43,10 +43,6 @@ class TuberResult:
         "Return a concise representation string"
         return repr(self.__dict__)
 
-    def __getitem__(self, item):
-        "Return a value by key"
-        return self.__dict__[item]
-
 
 def wrap_bytes_for_json(obj):
     """
@@ -197,7 +193,7 @@ if have_orjson:
     Codecs["orjson"] = Codec(decode=decode_orjson, encode=encode_orjson)
 
 
-def decode_json_client(response_data, encoding):
+def decode_json_client(response_data, encoding, return_dicts=False):
     if encoding is None:  # guess the typical default if unspecified
         encoding = "utf-8"
 
@@ -207,6 +203,8 @@ def decode_json_client(response_data, encoding):
                 return bytes(obj["bytes"])
             except e as ValueError:
                 pass
+        if return_dicts:
+            return obj
         return TuberResult(obj)
 
     return decode_json(response_data.decode(encoding), object_hook=ohook)
@@ -226,7 +224,9 @@ if have_cbor:
 
     Codecs["cbor"] = Codec(decode=decode_cbor, encode=encode_cbor)
 
-    def decode_cbor_client(response_data, encoding):
+    def decode_cbor_client(response_data, encoding, return_dicts=False):
+        if return_dicts:
+            return decode_cbor(response_data)
         return decode_cbor(response_data, object_hook=lambda dec, data: TuberResult(data))
 
     AcceptTypes["application/cbor"] = decode_cbor_client

--- a/tuber/codecs.py
+++ b/tuber/codecs.py
@@ -193,7 +193,7 @@ if have_orjson:
     Codecs["orjson"] = Codec(decode=decode_orjson, encode=encode_orjson)
 
 
-def decode_json_client(response_data, encoding, return_dicts=False):
+def decode_json_client(response_data, encoding, convert=True):
     if encoding is None:  # guess the typical default if unspecified
         encoding = "utf-8"
 
@@ -203,9 +203,7 @@ def decode_json_client(response_data, encoding, return_dicts=False):
                 return bytes(obj["bytes"])
             except e as ValueError:
                 pass
-        if return_dicts:
-            return obj
-        return TuberResult(obj)
+        return TuberResult(obj) if convert else obj
 
     return decode_json(response_data.decode(encoding), object_hook=ohook)
 
@@ -224,8 +222,8 @@ if have_cbor:
 
     Codecs["cbor"] = Codec(decode=decode_cbor, encode=encode_cbor)
 
-    def decode_cbor_client(response_data, encoding, return_dicts=False):
-        if return_dicts:
+    def decode_cbor_client(response_data, encoding, convert=True):
+        if not convert:
             return decode_cbor(response_data)
         return decode_cbor(response_data, object_hook=lambda dec, data: TuberResult(data))
 

--- a/tuber/codecs.py
+++ b/tuber/codecs.py
@@ -1,7 +1,6 @@
 from collections.abc import Sequence, Mapping
 from collections import namedtuple
 import sys
-import functools
 
 try:
     import numpy
@@ -44,42 +43,9 @@ class TuberResult:
         "Return a concise representation string"
         return repr(self.__dict__)
 
-    def __getitem__(self, objname):
-        """
-        Extract an item from this object for the given name.
-
-        The object may be a simple string name for an object attribute, or a list
-        path specifying the attributes and/or items to access.  For example, the
-        trivial object:
-
-            >>> class SomeObject: LIST = [1, 2, 3, 4]
-            >>> r = TuberResult(dict(cls=SomeObject()))
-
-        ...can be navigated as follows:
-
-            >>> r.cls.LIST[0]
-            1
-
-        ...equivalently
-
-            >>> r["cls", ("LIST", 0)]
-            1
-        """
-        try:
-            # simple object
-            if isinstance(objname, str):
-                return getattr(self, objname)
-
-            # object traversal
-            objname = [[x] if isinstance(x, str) else x for x in objname]
-
-            def agetter(obj, attr, *items):
-                return functools.reduce(lambda o, i: o[i], items, getattr(obj, attr))
-
-            return functools.reduce(lambda obj, x: agetter(obj, *x), objname, self)
-
-        except Exception as e:
-            raise e.__class__(f"{str(e)} (Invalid object name '{objname}')")
+    def __getitem__(self, item):
+        "Return a value by key"
+        return self.__dict__[item]
 
 
 def wrap_bytes_for_json(obj):

--- a/tuber/server.py
+++ b/tuber/server.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 import inspect
 import os
 import warnings
-import functools
 
-from .codecs import Codecs
+from .codecs import Codecs, TuberResult
 from . import schema
 
 __all__ = ["TuberRegistry", "TuberContainer", "TuberArray", "run", "main"]
@@ -265,7 +264,7 @@ class TuberArray(TuberContainer):
         return {"keys": keys, "values": resolve_object(value)}
 
 
-class TuberRegistry:
+class TuberRegistry(TuberResult):
     """
     Registry class.
     """
@@ -297,47 +296,6 @@ class TuberRegistry:
 
         for k, v in kwargs.items():
             setattr(self, k, v)
-
-    def __iter__(self):
-        return iter(self.__dict__)
-
-    def __getitem__(self, objname):
-        """
-        Extract an object from the registry for the given name.
-
-        The object name may be a simple string name for the registry entry, or
-        a list path specifying the attributes and/or items to access.  For
-        example, the trivial registry:
-
-            >>> class SomeObject: LIST = [1, 2, 3, 4]
-            >>> r = TuberRegistry(Class=SomeObject())
-
-        ...can be navigated as follows:
-
-            >>> r.Class.LIST[0]
-            1
-
-        ...equivalently
-
-            >>> r['Class', ('LIST', 0)]
-            1
-        """
-
-        try:
-            # simple object
-            if isinstance(objname, str):
-                return getattr(self, objname)
-
-            # object traversal
-            objname = [[x] if isinstance(x, str) else x for x in objname]
-
-            def agetter(obj, attr, *items):
-                return functools.reduce(lambda o, i: o[i], items, getattr(obj, attr))
-
-            return functools.reduce(lambda obj, x: agetter(obj, *x), objname, self)
-
-        except Exception as e:
-            raise e.__class__(f"{str(e)} (Invalid object name '{objname}')")
 
 
 class RequestHandler:


### PR DESCRIPTION
This allows handling return values from the server directly as dicts, which may be more intuitive for certain applications.

Also rearrange arguments so that default values for the response parsing can be set by the parent object or the context.

Add better documentation for all public API functions where these options are used.