### PR TITLE
Metadata cleanup

### DIFF
--- a/tuber/client.py
+++ b/tuber/client.py
@@ -730,6 +730,7 @@ class SimpleTuberObject:
             If given, assume this object is an attribute of this parent object.
         """
         self._tuber_objname = objname
+        self._tuber_resolved = False
         if parent is None:
             assert hostname, "Argument 'hostname' required"
             self._tuber_host = hostname
@@ -756,7 +757,7 @@ class SimpleTuberObject:
     def tuber_is_container(self):
         """True if object is a container (list or dict) of remote items,
         otherwise False if resolved or None if not resolved."""
-        if hasattr(self, "_tuber_meta"):
+        if self._tuber_resolved:
             return hasattr(self, "_items")
 
     def __getattr__(self, name: str):
@@ -799,11 +800,8 @@ class SimpleTuberObject:
         This class retrieves object-wide metadata, which is used to build
         up properties and methods with tab-completion and docstrings.
         """
-        if not force:
-            try:
-                return self._tuber_meta
-            except AttributeError:
-                pass
+        if self._tuber_resolved and not force:
+            return
 
         with self.tuber_context(convert_json=False, return_exceptions=False) as ctx:
             ctx._add_call(object=self._tuber_objname, resolve=True)
@@ -944,7 +942,7 @@ class SimpleTuberObject:
 
             setattr(self, "tuber_get", types.MethodType(tuber_get, self))
 
-        self._tuber_meta = meta
+        self._tuber_resolved = True
         return meta
 
 
@@ -966,11 +964,8 @@ class TuberObject(SimpleTuberObject):
         This class retrieves object-wide metadata, which is used to build
         up properties and methods with tab-completion and docstrings.
         """
-        if not force:
-            try:
-                return self._tuber_meta
-            except AttributeError:
-                pass
+        if self._tuber_resolved and not force:
+            return
 
         async with self.tuber_context(convert_json=False, return_exceptions=False) as ctx:
             ctx._add_call(object=self._tuber_objname, resolve=True)

--- a/tuber/client.py
+++ b/tuber/client.py
@@ -965,7 +965,7 @@ class TuberObject(SimpleTuberObject):
             meta = await ctx()
             meta = meta[0]
 
-        return self._resolve_meta(meta)
+        self._resolve_meta(meta)
 
     @staticmethod
     def _resolve_method(name: str, meta: TuberResult):

--- a/tuber/client.py
+++ b/tuber/client.py
@@ -744,6 +744,16 @@ class SimpleTuberObject:
 
     @property
     def is_container(self):
+        warnings.warn(
+            "Please replace TuberObject.is_container with "
+            "TuberObject.tuber_is_container - this maintains "
+            "namespace separation",
+            DeprecationWarning,
+        )
+        return self.tuber_is_container
+
+    @property
+    def tuber_is_container(self):
         """True if object is a container (list or dict) of remote items,
         otherwise False if resolved or None if not resolved."""
         if hasattr(self, "_tuber_meta"):

--- a/tuber/codecs.py
+++ b/tuber/codecs.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence, Mapping
 from collections import namedtuple
 import sys
+import types
 
 try:
     import numpy
@@ -30,18 +31,8 @@ except ImportError:
     have_cbor = False
 
 
-class TuberResult:
-    def __init__(self, d):
-        "Allow dotted accessors, like an object"
-        self.__dict__.update(d)
-
-    def __iter__(self):
-        "Make the results object iterate as a list of keys, like a dict"
-        return iter(self.__dict__)
-
-    def __repr__(self):
-        "Return a concise representation string"
-        return repr(self.__dict__)
+class TuberResult(types.SimpleNamespace):
+    pass
 
 
 def wrap_bytes_for_json(obj):
@@ -203,7 +194,7 @@ def decode_json_client(response_data, encoding, convert=True):
                 return bytes(obj["bytes"])
             except e as ValueError:
                 pass
-        return TuberResult(obj) if convert else obj
+        return TuberResult(**obj) if convert else obj
 
     return decode_json(response_data.decode(encoding), object_hook=ohook)
 
@@ -225,6 +216,6 @@ if have_cbor:
     def decode_cbor_client(response_data, encoding, convert=True):
         if not convert:
             return decode_cbor(response_data)
-        return decode_cbor(response_data, object_hook=lambda dec, data: TuberResult(data))
+        return decode_cbor(response_data, object_hook=lambda dec, data: TuberResult(**data))
 
     AcceptTypes["application/cbor"] = decode_cbor_client


### PR DESCRIPTION
* Replace TuberObject implementation with types.SimpleNamespace
* Use JSON metadata inside the TuberObject implementation, not TuberObjects
* Don't return anything on tuber_resolve()
* Deprecate is_container() in favour of tuber_is_container()