### PR TITLE
Bug fix for handling byte data with simplejson encoder

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,7 @@ def tuber_call(request, tuberd_host):
     URI = f"http://{tuberd_host}/tuber"
 
     accept = f"application/{request.param}"
-    loads = codecs.Codecs[request.param].decode
+    loads = lambda d: codecs.AcceptTypes[accept](d, encoding="utf-8", convert=False)
 
     # The tuber daemon can take a little while to start (in particular, it
     # sources this script as a registry) - rather than adding a magic sleep to

--- a/tests/test.py
+++ b/tests/test.py
@@ -58,6 +58,7 @@ class Types:
     FLOAT = 0.1234
     LIST = [1, 2, 3, 4]
     DICT = {"1": "2", "3": "4"}
+    BYTES = b"abc"
 
     # Properties are also exposed as default arguments to functions
     def string_function(self, arg=STRING):
@@ -79,6 +80,9 @@ class Types:
     def dict_function(self, arg=DICT):
         assert isinstance(arg, dict)
         return arg
+
+    def bytes_function(self, arg=None):
+        return self.BYTES
 
 
 class NumPy:
@@ -197,6 +201,7 @@ def test_property_types(tuber_call):
     assert tuber_call(object="Types", property="FLOAT") == Succeeded(pytest.approx(Types.FLOAT))
     assert tuber_call(object="Types", property="LIST") == Succeeded(Types.LIST)
     assert tuber_call(object="Types", property="DICT") == Succeeded(Types.DICT)
+    assert tuber_call(object="Types", property="BYTES") == Succeeded(Types.BYTES)
 
 
 def test_function_types_with_default_arguments(tuber_call):
@@ -205,6 +210,7 @@ def test_function_types_with_default_arguments(tuber_call):
     assert tuber_call(object="Types", method="float_function") == Succeeded(pytest.approx(Types.FLOAT))
     assert tuber_call(object="Types", method="list_function") == Succeeded(Types.LIST)
     assert tuber_call(object="Types", method="dict_function") == Succeeded(Types.DICT)
+    assert tuber_call(object="Types", method="bytes_function") == Succeeded(Types.BYTES)
 
 
 def test_function_types_with_correct_argument_types(tuber_call):

--- a/tuber/codecs.py
+++ b/tuber/codecs.py
@@ -13,8 +13,12 @@ except ImportError:
 # Prefer SimpleJSON, but fall back on built-in
 try:
     import simplejson as json
+
+    have_simplejson = True
 except ImportError:
     import json  # type: ignore[no-redef]
+
+    have_simplejson = False
 
 try:
     import orjson
@@ -165,6 +169,8 @@ def decode_json(response_data, **kwargs):
 
 
 def encode_json(obj, **kwargs):
+    if have_simplejson:
+        kwargs.setdefault("encoding", None)
     return json.dumps(obj, default=wrap_bytes_for_json, **kwargs)
 
 


### PR DESCRIPTION
By default, the `simplejson` encoder will attempt to convert byte objects into strings using the UTF-8 encoding.  However, the built-in `json` library encoder does not handle byte objects this way.

This PR sets the encoding to None for the `simplejson` encoder, so that the custom byte object wrapper is used identically for both `json` implementations.