### PR TITLE
Make requests and requests-futures optional for server package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,11 +160,11 @@ option, for example:
    CMAKE_ARGS="-DCMAKE_MODULE_PATH=/usr/local/share/cmake/Modules" pip install tuberd
 
 Optional dependencies may be installed to enable alternative encoding schemes (cbor, orjson)
-with and without numpy support, or the asyncio-enabled client interface:
+with and without numpy support, or the standard or asyncio-enabled client interface:
 
 .. code:: bash
 
-   pip install tuberd[async,cbor,numpy,orjson]
+   pip install tuberd[client,async,cbor,numpy,orjson]
 
 To run the test suite, install the development dependencies:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,15 +21,15 @@ classifiers=[
     "Operating System :: OS Independent",
 ]
 license = "BSD-3-Clause"
-dependencies = ["requests", "requests-futures"]
 dynamic = ["version", "scripts"]
 
 [project.optional-dependencies]
-async = ["aiohttp"]
+client = ["requests", "requests-futures"]
+async = ["aiohttp", "requests", "requests-futures"]
 cbor = ["cbor2"]
 numpy = ["numpy"]
 orjson = ["orjson"]
-dev = ["aiohttp", "cbor2", "jsonschema", "numpy", "orjson", "pytest", "pytest-asyncio"]
+dev = ["aiohttp", "cbor2", "jsonschema", "numpy", "orjson", "pytest", "pytest-asyncio", "requests", "requests-futures"]
 
 [tool.setuptools_scm]
 write_to = "tuber/_version.py"


### PR DESCRIPTION
This significantly reduces the size of the build on embedded systems with limited file system image size.