### PR TITLE
fix(build): be explicit about CMake build and source directories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,11 @@ class CMakeBuild(build_ext):
 
         if not rtlib.exists() or (include_tests and not tmlib.exists()):
             # build once
-            subprocess.run(["cmake", ext.sourcedir, *cmake_args], cwd=build_temp, check=True)
-            subprocess.run(["cmake", "--build", "."], cwd=build_temp, check=True)
+            subprocess.run(
+                ["cmake", "-S", ext.sourcedir, "-B", str(build_temp), *cmake_args],
+                check=True,
+            )
+            subprocess.run(["cmake", "--build", str(build_temp)], check=True)
 
             # add server module
             tuber_lib = Path(self.build_lib) / "tuber"

--- a/tuber/client.py
+++ b/tuber/client.py
@@ -14,7 +14,6 @@ import functools
 from . import TuberError, TuberStateError, TuberRemoteError
 from .codecs import AcceptTypes, Codecs, TuberResult
 
-
 __all__ = [
     "TuberObject",
     "SimpleTuberObject",
@@ -351,7 +350,7 @@ class SimpleContext:
         calls = []
         futures = []
         while self.calls:
-            (c, f) = self.calls.pop(0)
+            c, f = self.calls.pop(0)
 
             calls.append(c)
             futures.append(f)
@@ -617,7 +616,7 @@ class Context(SimpleContext):
         calls = []
         futures = []
         while self.calls:
-            (c, f) = self.calls.pop(0)
+            c, f = self.calls.pop(0)
 
             calls.append(c)
             futures.append(f)


### PR DESCRIPTION
This fixes scenarios where a stale CMakeCache is already present and confuses 'pip install -e .'. It's good hygiene but not strictly necessary.