### PR TITLE
Remove pybind11 and cmake from build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,5 @@
 [build-system]
 requires = [
-    "cmake>=3.12",
-    "pybind11",
     "setuptools>=61",
     "setuptools_scm[toml]>=6.3",
     "wheel",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ import re
 import subprocess
 import sys
 import sysconfig
-import pybind11
 from pathlib import Path
 
 from setuptools import Extension, setup
@@ -38,6 +37,8 @@ if not any(["Python_ROOT_DIR" in a for a in cmake_args]):
     cmake_args += [f"-DPython_ROOT_DIR={pyroot}"]
 
 if not any(["pybind11_DIR" in a for a in cmake_args]):
+    import pybind11
+
     pbdir = pybind11.get_cmake_dir()
     cmake_args += [f"-Dpybind11_DIR={pbdir}"]
 


### PR DESCRIPTION
When cross-compiling this package, e.g. using buildroot, the pybind11 and cmake python packages are not installed on the host or target PYTHONPATH, which causes a missing dependency error to be raised when attempting to build the package.  Remove these dependencies from the pyproject.toml file, and let the setup.py script handle these instead.