### PR TITLE
TuberContext: respect cancellation; yield inside contexts without deadlock

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
 import os
 import pytest
 import requests
+import socket
 import subprocess
 import sys
+import time
 import warnings
 
 from tuber import codecs
@@ -74,6 +76,21 @@ def tuberd(request, pytestconfig):
         argv.extend(["--json", "orjson"])
 
     s = subprocess.Popen(argv)
+
+    # The server takes a moment to come up (it sources this test file as a
+    # registry) - don't release tests against it until it's listening.
+    for _ in range(100):
+        if s.poll() is not None:
+            raise RuntimeError(f"tuberd exited on startup with code {s.returncode}")
+        try:
+            with socket.create_connection(("localhost", int(TUBERD_PORT)), timeout=0.1):
+                break
+        except OSError:
+            time.sleep(0.1)
+    else:
+        s.terminate()
+        raise RuntimeError("tuberd did not start listening")
+
     yield s
     s.terminate()
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -111,6 +111,14 @@ class WarningsClass:
         return True
 
 
+class SlowObject:
+    def sleep(self, seconds):
+        import time
+
+        time.sleep(seconds)
+        return seconds
+
+
 registry = {
     "NullObject": NullObject(),
     "ObjectWithMethod": ObjectWithMethod(),
@@ -127,6 +135,7 @@ registry = {
     "Types": Types(),
     "NumPy": NumPy(),
     "Warnings": WarningsClass(),
+    "SlowObject": SlowObject(),
     "Wrapper": tm.Wrapper(),
 }
 
@@ -524,6 +533,72 @@ async def test_tuberpy_async_context_with_exception(resolve):
     # exception too)
     with pytest.raises(tuber.TuberRemoteError):
         await tuber_result(r3)
+
+
+@pytest.mark.asyncio
+async def test_tuberpy_async_context_await_flushes(accept_types, tuberd_host):
+    """Awaiting a queued call mid-context flushes the calls queued so far."""
+    s = await tuber.resolve(tuberd_host, "Wrapper", accept_types)
+
+    async with tuber_context(s) as ctx:
+        r1 = ctx.increment([1, 2, 3])
+        r2 = await ctx.increment([2, 3, 4])
+        assert r2 == [3, 4, 5]
+
+        # the await dispatched everything queued before it, too
+        assert r1.done()
+        assert r1.result() == [2, 3, 4]
+
+        # the context remains usable after a mid-context flush
+        r3 = await ctx.increment([3, 4, 5])
+        assert r3 == [4, 5, 6]
+
+    # nothing left over for the exit flush
+    assert not ctx.calls
+
+
+@pytest.mark.asyncio
+async def test_tuberpy_async_context_await_flush_exception(accept_types, tuberd_host):
+    """Errors anywhere in the flushed batch surface at the triggering await."""
+    s = await tuber.resolve(tuberd_host, "Wrapper", accept_types)
+
+    async with tuber_context(s) as ctx:
+        r1 = ctx.increment([1, 2, 3])  # fine
+        with pytest.raises(tuber.TuberRemoteError):
+            await ctx.increment(4)  # wrong type
+
+        # the passing call in the batch still resolved normally
+        assert (await r1) == [2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_tuberpy_async_context_cancelled_call(accept_types, tuberd_host):
+    """A cancelled per-call future doesn't spoil the rest of the batch."""
+    s = await tuber.resolve(tuberd_host, "Wrapper", accept_types)
+
+    async with tuber_context(s) as ctx:
+        r1 = ctx.increment([1, 2, 3])
+        r2 = ctx.increment([2, 3, 4])
+        r2.cancel()
+
+    assert (await r1) == [2, 3, 4]
+    with pytest.raises(asyncio.CancelledError):
+        await r2
+
+
+@pytest.mark.asyncio
+async def test_tuberpy_async_context_await_timeout(accept_types, tuberd_host):
+    """A timed-out awaiter doesn't abort the flush other queued calls rely on."""
+    s = await tuber.resolve(tuberd_host, "SlowObject", accept_types)
+
+    async with tuber_context(s) as ctx:
+        r1 = ctx.sleep(0.1)
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(ctx.sleep(0.5), timeout=0.2)
+
+        # the shielded flush completes in the background and resolves the
+        # sibling call despite the cancellation
+        assert (await r1) == 0.1
 
 
 @pytest.mark.asyncio

--- a/tuber/client.py
+++ b/tuber/client.py
@@ -457,6 +457,11 @@ class SimpleContext:
                 for w in getkey(r, "warnings"):
                     warnings.warn(w)
 
+            # A future the caller has cancelled (e.g. via a timeout) can no
+            # longer accept a result - don't let it spoil the batch.
+            if f.cancelled():
+                continue
+
             # Resolve either a result or an error
             if haskey(r, "error") and getkey(r, "error"):
                 err = getkey(r, "error")
@@ -470,17 +475,22 @@ class SimpleContext:
                 else:
                     f.set_exception(TuberError("Result has no 'result' attribute"))
 
-        # Return a list of results
+        # Return a list of results. Futures the caller has cancelled have no
+        # result to collect - stand in with a CancelledError or None so the
+        # rest of the batch is unaffected.
         if return_exceptions:
             out = []
             for f in futures:
+                if f.cancelled():
+                    out.append(asyncio.CancelledError())
+                    continue
                 try:
                     out.append(f.result())
                 except Exception as e:
                     out.append(e)
             return out
 
-        return [f.result() for f in futures]
+        return [None if f.cancelled() else f.result() for f in futures]
 
     def _receive(
         self,
@@ -581,6 +591,39 @@ class SimpleContext:
         return self.receive(resp)
 
 
+class ContextFuture(asyncio.Future):
+    """A Future for a call queued in a Context.
+
+    Awaiting this future before the Context has been flushed sends every call
+    queued so far (in-order, as a single request) and returns this call's
+    result. This allows results to be retrieved without exiting the context:
+
+        >>> async with obj.tuber_context() as ctx:
+        ...     ctx.some_method()
+        ...     result = await ctx.another_method()  # doctest: +SKIP
+
+    Because the flush dispatches the whole batch, an error from any queued
+    call is raised at the await that triggered the flush.
+    """
+
+    def __init__(self, context: "Context"):
+        super().__init__(loop=asyncio.get_running_loop())
+        self._context = context
+
+    def __await__(self):
+        # If we're unresolved and calls (ours among them) are still queued,
+        # flush the context. If the queue is empty, either we're already
+        # resolved or a flush is in flight - fall through and wait for it.
+        # The flush is shielded because it acts on the whole batch:
+        # cancelling one awaiter (e.g. via a timeout) must not abort the
+        # request that other queued calls are counting on.
+        if not self.done() and self._context.calls:
+            yield from asyncio.shield(self._context()).__await__()
+        return (yield from super().__await__())
+
+    __iter__ = __await__  # make compatible with 'yield from'
+
+
 class Context(SimpleContext):
     """An asynchronous context container for TuberCalls. Permits calls to be
     aggregated.
@@ -604,8 +647,7 @@ class Context(SimpleContext):
         raise NotImplementedError
 
     def _add_call(self, **request):
-        loop = asyncio.get_running_loop()
-        future = loop.create_future()
+        future = ContextFuture(self)
         self.calls.append((request, future))
         return future
 


### PR DESCRIPTION
Previously,
    
    async with tuber_context(s) as ctx:
        await ctx.some_call()
    
...would have deadlocked because the context-level future (which resolved any call-level futures) did not fall out of scope until after the call-level future was awaited.
    
We've taught these call-level contexts to resolve the higher-level contexts as needed, now, in order to guarantee forward progress.
